### PR TITLE
Added Support for tons of new mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,56 @@ global.more_recipe_types.botanypots.fertilizer(event, <Input Fertilizer>, <Min t
 global.more_recipe_types.botanypots.soil(event, <Input soil>, [<Soil categories>], <Growth modifier (float between -1 and 1, 0 by default)>, <Display block (Input soil by default. Change if soil is item!)>)
 ```
 
+### Elemental Craft
+
+#### Binding (Element Binding)
+
+```js
+global.more_recipe_types.elementalcraft.binding(event, [<Input items>], <Output item>, <Element Type>, <Element Amount (1000 by default)>)
+```
+
+#### Crystallization (Gem Crystallization)
+
+```js
+global.more_recipe_types.elementalcraft.crystallization(event, [<Gem input item>, <Crystal input item>, <Shard input item>], [[<Output item>, <Weight (1 by default)>, <Quality (null by default)>], ...], <Element Type>, <Element Amount (1000 by default)>)
+```
+
+#### Grinding
+
+```js
+global.more_recipe_types.elementalcraft.grinding(event, <Input item>, <Output item>, <Element Amount (1000 by default)>)
+```
+
+#### Tool Infusion (Element Infusion)
+
+```js
+global.more_recipe_types.elementalcraft.tool_infusion(event, <Input item>, <Tool infusion type (e.g.: "elementalcraft:fire_aspect")>, <Element Amount (1000 by default)>)
+```
+
+#### Infusion (Element Infusion)
+
+```js
+global.more_recipe_types.elementalcraft.infusion(event, <Input item>, <Output Item>, <Element Type>, <Element Amount (1000 by default)>)
+```
+
+#### Inscription (Rune Inscription)
+
+```js
+global.more_recipe_types.elementalcraft.inscription(event, [<Slate input item>, <3 other input items>], [<Output item>, <nbt>], <Element Type>, <Element Amount (1000 by default)>)
+```
+
+#### Pure Infusion
+
+```js
+global.more_recipe_types.elementalcraft.pureinfusion(event, [<middle input item>, <Water input item>, <Fire input item>, <Earth input item>, <Air input item>], <Output Item>, <Element Amount (1000 by default)>)
+```
+
+#### Spell Craft
+
+```js
+global.more_recipe_types.elementalcraft.spell_craft(event, [<Gem input item>, <Crystal input item>], [<Output item>, <nbt>])
+```
+
 ### Powah
 
 #### Energizing

--- a/README.md
+++ b/README.md
@@ -205,6 +205,20 @@ global.more_recipe_types.botanypots.soil(event, <Input soil>, [<Soil categories>
 global.more_recipe_types.draconicevolution.fusion_crafting(event, <Main input item>, [<side Input items>], <Output item>, <Tier (of DRACONIUM = default, WYVERN, DRACONIC, CHAOTIC)>, <Energy (100000 by default)>)
 ```
 
+### DivineRPG
+
+#### Infusion Table
+
+```js
+global.more_recipe_types.divinerpg.infusion_table(event, <Input item>, <Input template>, <Output item>)
+```
+
+#### Fusion Crafting
+
+```js
+global.more_recipe_types.draconicevolution.fusion_crafting(event, <Main input item>, [<side Input items>], <Output item>, <Tier (of DRACONIUM = default, WYVERN, DRACONIC, CHAOTIC)>, <Energy (100000 by default)>)
+```
+
 ### Elemental Craft
 
 #### Binding (Element Binding)

--- a/README.md
+++ b/README.md
@@ -174,14 +174,6 @@ global.more_recipe_types.elementalcraft.pureinfusion(event, [<middle input item>
 global.more_recipe_types.elementalcraft.spell_craft(event, [<Gem input item>, <Crystal input item>], [<Output item>, <nbt>])
 ```
 
-### Powah
-
-#### Energizing
-
-```js
-global.more_recipe_types.powah.energizing(event, [<Input items>], <Output item>, <Energy (100 by default)>)
-```
-
 ### Industrial Foregoing
 
 #### Dissolution Chamber
@@ -194,4 +186,24 @@ global.more_recipe_types.industrialforegoing.dissolution_chamber(event, [<Input 
 
 ```js
 global.more_recipe_types.industrialforegoing.fluid_extractor(event, <Input block>, Fluid.of(<Output fluid>, <Amount>), <Block damage chance (float, 0% by default)>, <Result block ("minecraft:air" by default)>)
+```
+
+#### Laser Drill (Ore / Fluid)
+
+```js
+global.more_recipe_types.industrialforegoing.laser_drill(event, <Output item / Fluid.of(<Output Fluid>, <Amount>)>, <Catalyst Item>, [[[[<List values (empty by default)>], <List Blacklist ? (else whitelist, false by default)>, <List type ("minecraft:worldgen/biome" by default)>], [<Min depth (0 by default)>, <Max depth (64 by default)>], <Weight (1 by default)>], ...], <Fluid recipe ? (false by default)>, <Entity (only if Fluid recipe, no entity by default)>)
+```
+
+#### Stonework Generate
+
+```js
+global.more_recipe_types.industrialforegoing.stonework_generate(event, <Output Item>, [<Water requirement (1000 by default)>, <Water usage (0 by default)>], [<Lava requirement (1000 by default)>, <Lava usage (0 by default)>])
+```
+
+### Powah
+
+#### Energizing
+
+```js
+global.more_recipe_types.powah.energizing(event, [<Input items>], <Output item>, <Energy (100 by default)>)
 ```

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ global.more_recipe_types.ars_nouveau.enchanting_apparatus(event, <Middle input i
 #### Crush (Glyph)
 
 ```js
-global.more_recipe_types.ars_nouveau.crush(event, <Input item>, [Ingredient.of(<Output item>).withChance(<Chance>), ...])```
+global.more_recipe_types.ars_nouveau.crush(event, <Input item>, [Ingredient.of(<Output item>).withChance(<Chance>), ...])
+```
 
 #### Glyph Recipe (Glyph Press)
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,26 @@ global.more_recipe_types.atum.quern(event, <Input item>, <Output item>, <Rotatio
 global.more_recipe_types.atum.spinning_wheel(event, <Input item>, <Output item>, <Rotations (1 by default)>)
 ```
 
+### Better End Forge
+
+#### Alloying
+
+```js
+global.more_recipe_types.betterendforge.alloying(event, [<Input items>], <Output item>, <Experience (float, 1 by default)>, <Time in ticks (200 by default)>)
+```
+
+#### Anvil Smithing
+
+```js
+global.more_recipe_types.betterendforge.anvil_smithing(event, <Input item>, <Output item>, <Tool level (0 by default = wood/gold)>, <Anvil level (1 by default)>, <Damage to tool (1 by default)>)
+```
+
+#### Infusion
+
+```js
+global.more_recipe_types.betterendforge.infusion(event, <Middle Input item>, [<Catalyst Input items (clockwise from top middle)>], <Output item>, <Time in seconds (100 by default)>)
+```
+
 ### (Space) Boss Tools
 
 #### Blasting

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ global.more_recipe_types.appliedenergistics2.inscriber(event, [<Top input item>,
 #### Block Transmutation (Starlight Transmutation)
 
 ```js
-global.more_recipe_types.astralsorcery.block_transmutation(event, [<Input block>], <Output block>, <Starlight>)
+global.more_recipe_types.astralsorcery.block_transmutation(event, [<Input block (can use multiple)>], <Output block>, <Starlight>)
 ```
 
 #### Infuser (Starlight Infusion)
 
 ```js
-global.more_recipe_types.astralsorcery.infuser(event, <Input item>, <Output item>, <Duration (100 by default)>, <Consumption chance (float, 0.1 by default)>, [>Consume multiple fluids (False by default)>, <Accept chalice input (False by default)>, <Copy NBT to output (False by default)>](Array can contain any number of elements), <Input fluid id name ("astralsorcery:liquid_starlight" by default)>)
+global.more_recipe_types.astralsorcery.infuser(event, <Input item>, <Output item>, <Duration (100 by default)>, <Consumption chance (float, 0.1 by default)>, [>Consume multiple fluids (False by default)>, <Accept chalice input (True by default)>, <Copy NBT to output (False by default)>](Array can contain any number of booleans), <Input fluid id name ("astralsorcery:liquid_starlight" by default)>)
 ```
 
 #### Lightwell

--- a/README.md
+++ b/README.md
@@ -174,6 +174,40 @@ global.more_recipe_types.elementalcraft.pureinfusion(event, [<middle input item>
 global.more_recipe_types.elementalcraft.spell_craft(event, [<Gem input item>, <Crystal input item>], [<Output item>, <nbt>])
 ```
 
+### FTB Industrial Contraptions
+
+#### Antimatter Boost
+
+```js
+global.more_recipe_types.ftbic.antimatter_boost(event, <Input item>, <Boost (1000 by default)>)
+```
+
+#### Basic Generator Fuel
+
+```js
+global.more_recipe_types.ftbic.basic_generator_fuel(event, <Input item>, <Burn ticks (1 tick = 10 zaps, 200 by default)>)
+```
+
+#### Other Machines
+
+Supported types:
+
+- canning
+- compressing
+- extruding
+- macerating
+- rolling
+- seperating
+
+```js
+global.more_recipe_types.ftbic.<type>(event, [<Input items>], [<Output Items>])
+```
+
+Some notes:
+
+- To use nbt in input items use Item.of(<Input item>, <nbt>)
+- To use chance in output items use Item.of(<Input item>).withChance(<Chance>)
+
 ### Industrial Foregoing
 
 #### Dissolution Chamber

--- a/README.md
+++ b/README.md
@@ -353,3 +353,53 @@ global.more_recipe_types.silents_mechanisms.refining(event, [<Input fluid>, <Amo
 ```js
 global.more_recipe_types.silents_mechanisms.solidifying(event, [<Input fluid>, <Amount (1000 by default)>], <Output item>, <Time in ticks (200 by default)>)
 ```
+
+### Tinker's Construct
+
+#### Alloy (Alloying)
+
+```js
+global.more_recipe_types.tconstruct.alloy(event, [[<Input fluid>, <Amount (1000 by default)>], ...], Fluid.of(<Output fluid>, <Amount>), <Temperature (100 by default)>)
+```
+
+#### Casting (Table / Basin)
+
+```js
+global.more_recipe_types.tconstruct.casting(event, [<Input fluid>, <Amount (1000 by default)>], <Input Cast>, <Output item>, <Basin ? (else table, false by default)>, <Cast consumed ? (false by default)>, <Time in ticks (60 by default)>)
+```
+
+#### Entity Melting
+
+```js
+global.more_recipe_types.tconstruct.entity_melting(event, <Entity>, Fluid.of(<Output fluid>, <Amount>), <Damage (1 by default)>)
+```
+
+#### Melting
+
+```js
+global.more_recipe_types.tconstruct.melting(event, <Input item>, Fluid.of(<Output fluid>, <Amount>), <Temperature (100 by default)>, <Time in ticks (300 by default)>)
+```
+
+#### Molding (Table)
+
+```js
+global.more_recipe_types.tconstruct.molding_table(event, <Input Cast>, <Input item>, <Output cast>)
+```
+
+#### Part Builder
+
+```js
+global.more_recipe_types.tconstruct.part_builder(event, <Input pattern>, <Output Part>, <Cost (1 by default)>)
+```
+
+#### Severing
+
+```js
+global.more_recipe_types.tconstruct.severing(event, <Entity>, <Output item>)
+```
+
+#### Casting Table with Parts (like Part Builder)
+
+```js
+global.more_recipe_types.tconstruct.table_casting_material(event, <Input cast>, <Output Part>, <Cost (1 by default)>)
+```

--- a/README.md
+++ b/README.md
@@ -90,6 +90,26 @@ global.more_recipe_types.botania.runic_altar(event, [<Input items>], <Output ite
 global.more_recipe_types.botania.terra_plate(event, [<Input items>], <Output item>, <Mana (100000 by default)>)
 ```
 
+### Botany Pots
+
+#### Crop
+
+```js
+global.more_recipe_types.botanypots.crop(event, <Input seed>, [<Soil categories>], [[<Output item>, <Chance (float, 1 by default)>, <Min rolls (1 by default)>, <Max Rolls (1 by default)>], ...], <Growth ticks (1200 by default)>, <Display block (Input seed by default. Change if seed is item!)>)
+```
+
+#### Fertilizer
+
+```js
+global.more_recipe_types.botanypots.fertilizer(event, <Input Fertilizer>, <Min ticks (100 by default)>, <Max ticks (Min ticks + 100 by default)>)
+```
+
+#### Soil
+
+```js
+global.more_recipe_types.botanypots.soil(event, <Input soil>, [<Soil categories>], <Growth modifier (float between -1 and 1, 0 by default)>, <Display block (Input soil by default. Change if soil is item!)>)
+```
+
 ### Powah
 
 #### Energizing

--- a/README.md
+++ b/README.md
@@ -442,6 +442,20 @@ global.more_recipe_types.powah.energizing(event, [<Input items>], <Output item>,
 global.more_recipe_types.psi.trick_crafting(event, <Input item>, <Output item>, <Cad assemby>, <Trick>, <Dimension (Isn't listed in JEI)>)
 ```
 
+### Silent Gear
+
+#### Compounding
+
+```js
+global.more_recipe_types.silentgear.compounding(event, [<Input items>], <Output item>, <Gem Compounding ? (else Metal, false by default)>)
+```
+
+#### Salvaging
+
+```js
+global.more_recipe_types.silentgear.salvaging(event, <Input item>, [<Output items>])
+```
+
 ### Silent's Mechanism's
 
 #### Alloy Smelting

--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ All new types are functions inside of the `global` object. They should be called
 
 ## Types
 
+### Applied Energistics 2
+
+#### Grinder
+
+```js
+global.more_recipe_types.appliedenergistics2.grinder(event, <Input item>, [<Output items>], <Turns (4 by default)>)
+```
+
+#### Inscriber
+
+```js
+global.more_recipe_types.appliedenergistics2.inscriber(event, [<Top input item>, <Middle input item>, <Bottom input item> (all air by default)], <Output item>, <Keep top and bottom (false by default)>)
+```
+
 ### Powah
 
 #### Energizing

--- a/README.md
+++ b/README.md
@@ -222,6 +222,20 @@ global.more_recipe_types.elementalcraft.pureinfusion(event, [<middle input item>
 global.more_recipe_types.elementalcraft.spell_craft(event, [<Gem input item>, <Crystal input item>], [<Output item>, <nbt>])
 ```
 
+### Evil Craft
+
+#### Blood Infuser
+
+```js
+global.more_recipe_types.evilcraft.blood_infuser(event, <Input item>, Fluid.of(<Input fluid>, <Amount>), <Output item>, <Tier (0-3, 0 by default)>, <time in ticks (200 by default)>, <Experience (float, 0.1 by default)>)
+```
+
+#### Environmental Accumulator / Sanguinary Environmental Accumulator
+
+```js
+global.more_recipe_types.evilcraft.environmental_accumulator(event, <Input item>, <Input action (e.g. LIGHTNING)>, <Output item>, <Output weather (ANY, CLEAR, RAIN, LIGHTNING)>, <time in ticks (100 by default)>, <Cooldown time in ticks (0 by default)>)
+```
+
 ### FTB Industrial Contraptions
 
 #### Antimatter Boost

--- a/README.md
+++ b/README.md
@@ -40,11 +40,55 @@ global.more_recipe_types.astralsorcery.infuser(event, <Input item>, <Output item
 global.more_recipe_types.astralsorcery.lightwell(event, <Input item>, <Output fluid id name>, <Production multiplier (float, 1 by default)>, <Shatter multiplier (float, lower = faster shatter, 10 by default)>, <color (white color by default)>)
 ```
 
-#### liquid Interaction
+#### Liquid Interaction
 
 ```js
 global.more_recipe_types.astralsorcery.liquid_interaction(event, [Fluid.of(<Input fluid 1>, <Amount>), <Chance consume fluid 1 (float, 100% by default)>], [Fluid.of(<Input fluid 2>, <Amount>), <Chance consume fluid 2 (float, 100% by default)>], <Output item>, <weight (1 by default)>)
 ```  
+
+### Botania
+
+#### Brew (Botanical Brewery)
+
+```js
+global.more_recipe_types.botania.brew(event, [<Input items>], <Output Brew id name (example: "botania:haste")>)
+```
+
+#### Elven Trade
+
+```js
+global.more_recipe_types.botania.elven_trade(event, [<Input items>], [<Output items>])
+```
+
+#### Mana Infusion
+
+```js
+global.more_recipe_types.botania.mana_infusion(event, <Output items>, <Output item>, <Mana (1000 by default)>, "Catalyst")
+```
+
+#### Petal Aplothecary
+
+```js
+global.more_recipe_types.botania.petal_apothecary(event, [<Input items>], <Output item>)
+```
+
+#### Pure Daisy
+
+```js
+global.more_recipe_types.botania.pure_daisy(event, <Input block>, <Output block>)
+```
+
+#### Runic Altar
+
+```js
+global.more_recipe_types.botania.runic_altar(event, [<Input items>], <Output item>, <Mana (5000 by default)>)
+```
+
+#### Terra Plate (Terrestrial Agglomeration)
+
+```js
+global.more_recipe_types.botania.terra_plate(event, [<Input items>], <Output item>, <Mana (100000 by default)>)
+```
 
 ### Powah
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,32 @@ global.more_recipe_types.appliedenergistics2.grinder(event, <Input item>, [<Outp
 global.more_recipe_types.appliedenergistics2.inscriber(event, [<Top input item>, <Middle input item>, <Bottom input item> (all air by default)], <Output item>, <Keep top and bottom (false by default)>)
 ```
 
+### Astral Sorcery
+
+#### Block Transmutation (Starlight Transmutation)
+
+```js
+global.more_recipe_types.astralsorcery.block_transmutation(event, [<Input block>], <Output block>, <Starlight>)
+```
+
+#### Infuser (Starlight Infusion)
+
+```js
+global.more_recipe_types.astralsorcery.infuser(event, <Input item>, <Output item>, <Duration (100 by default)>, <Consumption chance (float, 0.1 by default)>, [>Consume multiple fluids (False by default)>, <Accept chalice input (False by default)>, <Copy NBT to output (False by default)>](Array can contain any number of elements), <Input fluid id name ("astralsorcery:liquid_starlight" by default)>)
+```
+
+#### Lightwell
+
+```js
+global.more_recipe_types.astralsorcery.lightwell(event, <Input item>, <Output fluid id name>, <Production multiplier (float, 1 by default)>, <Shatter multiplier (float, lower = faster shatter, 10 by default)>, <color (white color by default)>)
+```
+
+#### liquid Interaction
+
+```js
+global.more_recipe_types.astralsorcery.liquid_interaction(event, [Fluid.of(<Input fluid 1>, <Amount>), <Chance consume fluid 1 (float, 100% by default)>], [Fluid.of(<Input fluid 2>, <Amount>), <Chance consume fluid 2 (float, 100% by default)>], <Output item>, <weight (1 by default)>)
+```  
+
 ### Powah
 
 #### Energizing

--- a/README.md
+++ b/README.md
@@ -386,6 +386,14 @@ global.more_recipe_types.pneumaticcraft.thermo_plant(event, <Input item>, [<Inpu
 global.more_recipe_types.powah.energizing(event, [<Input items>], <Output item>, <Energy (100 by default)>)
 ```
 
+### Psi
+
+#### Trick Crafting (Spell Infusion)
+
+```js
+global.more_recipe_types.psi.trick_crafting(event, <Input item>, <Output item>, <Cad assemby>, <Trick>, <Dimension (Isn't listed in JEI)>)
+```
+
 ### Silent's Mechanism's
 
 #### Alloy Smelting

--- a/README.md
+++ b/README.md
@@ -303,3 +303,53 @@ global.more_recipe_types.pneumaticcraft.thermo_plant(event, <Input item>, [<Inpu
 ```js
 global.more_recipe_types.powah.energizing(event, [<Input items>], <Output item>, <Energy (100 by default)>)
 ```
+
+### Silent's Mechanism's
+
+#### Alloy Smelting
+
+```js
+global.more_recipe_types.silents_mechanisms.alloy_smelting(event, [[[<Input item>, ...], <Amount>], ...], <Output item>, <Time in ticks (200 by default)>)
+```
+
+#### Compressing
+
+```js
+global.more_recipe_types.silents_mechanisms.compressing(event, [[<Input item>, ...], <Amount>], <Output item>, <Time in ticks (200 by default)>)
+```
+
+#### Crushing
+
+```js
+global.more_recipe_types.silents_mechanisms.crushing(event, <Input item>, [<Output items>], <Time in ticks (200 by default)>)
+```
+
+#### Drying
+
+```js
+global.more_recipe_types.silents_mechanisms.drying(event, <Input item>, <Output item>, <Time in ticks (200 by default)>)
+```
+
+#### Infusing
+
+```js
+global.more_recipe_types.silents_mechanisms.infusing(event, <Input item>, [<Input fluid>, <Amount (1000 by default)>], <Output item>, <Time in ticks (200 by default)>)
+```
+
+#### Mixing
+
+```js
+global.more_recipe_types.silents_mechanisms.mixing(event, [[<Input fluid>, <Amount (1000 by default)>], ...], Fluid.of(<Output fluid>, <Amount>), <Time in ticks (200 by default)>)
+```
+
+#### Refining
+
+```js
+global.more_recipe_types.silents_mechanisms.refining(event, [<Input fluid>, <Amount (1000 by default)>], [Fluid.of(<Output fluid>, <Amount>), ...], <Time in ticks (200 by default)>)
+```
+
+#### Solidifying
+
+```js
+global.more_recipe_types.silents_mechanisms.solidifying(event, [<Input fluid>, <Amount (1000 by default)>], <Output item>, <Time in ticks (200 by default)>)
+```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Quickstart
 
-All new types are functions inside of the `global` object. They should be called inside of the `recipes` event like so: `global.more_recipe_types.<mod>.<type>(event, {args}, <id>)`. For more info look at the section below.
+All new types are functions inside of the `global` object. They should be called inside of the `recipes` event like so: `global.mrt.<mod>.<type>(event, {args}, <id>)`. For more info look at the section below.
 
 ## Types
 
@@ -11,13 +11,13 @@ All new types are functions inside of the `global` object. They should be called
 #### Infusion
 
 ```js
-global.more_recipe_types.aoa3.infusion(event, <Main input item>, [<Other input items>], <Output item>, <id>)
+global.mrt.aoa3.infusion(event, <Main input item>, [<Other input items>], <Output item>, <id>)
 ```
 
 #### Upgrade Kit
 
 ```js
-global.more_recipe_types.aoa3.upgrade_kit(event, <Input item>, <Upgrade item>, <Output item>, <id>)
+global.mrt.aoa3.upgrade_kit(event, <Input item>, <Upgrade item>, <Output item>, <id>)
 ```
 
 ### Applied Energistics 2
@@ -25,13 +25,13 @@ global.more_recipe_types.aoa3.upgrade_kit(event, <Input item>, <Upgrade item>, <
 #### Grinder
 
 ```js
-global.more_recipe_types.appliedenergistics2.grinder(event, <Input item>, [<Output items>], <Turns (4 by default)>, <id>)
+global.mrt.appliedenergistics2.grinder(event, <Input item>, [<Output items>], <Turns (4 by default)>, <id>)
 ```
 
 #### Inscriber
 
 ```js
-global.more_recipe_types.appliedenergistics2.inscriber(event, [<Top input item>, <Middle input item>, <Bottom input item> (all air by default)], <Output item>, <Keep top and bottom (false by default)>, <id>)
+global.mrt.appliedenergistics2.inscriber(event, [<Top input item>, <Middle input item>, <Bottom input item> (all air by default)], <Output item>, <Keep top and bottom (false by default)>, <id>)
 ```
 
 ### Ars Nouveau
@@ -39,19 +39,19 @@ global.more_recipe_types.appliedenergistics2.inscriber(event, [<Top input item>,
 #### Enchanting Apparatus
 
 ```js
-global.more_recipe_types.ars_nouveau.enchanting_apparatus(event, <Middle input item>, [<Side input items>], <Output item>, <id>)
+global.mrt.ars_nouveau.enchanting_apparatus(event, <Middle input item>, [<Side input items>], <Output item>, <id>)
 ```
 
 #### Crush (Glyph)
 
 ```js
-global.more_recipe_types.ars_nouveau.crush(event, <Input item>, [Ingredient.of(<Output item>).withChance(<Chance>), ...], <id>)
+global.mrt.ars_nouveau.crush(event, <Input item>, [Ingredient.of(<Output item>).withChance(<Chance>), ...], <id>)
 ```
 
 #### Glyph Recipe (Glyph Press)
 
 ```js
-global.more_recipe_types.ars_nouveau.glyph_recipe(event, <Input item>, <Output item>, <Tier (1-3, 1 by default)>, <id>)
+global.mrt.ars_nouveau.glyph_recipe(event, <Input item>, <Output item>, <Tier (1-3, 1 by default)>, <id>)
 ```
 
 ### Astral Sorcery
@@ -59,25 +59,25 @@ global.more_recipe_types.ars_nouveau.glyph_recipe(event, <Input item>, <Output i
 #### Block Transmutation (Starlight Transmutation)
 
 ```js
-global.more_recipe_types.astralsorcery.block_transmutation(event, [<Input block (can use multiple)>], <Output block>, <Starlight>, <id>)
+global.mrt.astralsorcery.block_transmutation(event, [<Input block (can use multiple)>], <Output block>, <Starlight>, <id>)
 ```
 
 #### Infuser (Starlight Infusion)
 
 ```js
-global.more_recipe_types.astralsorcery.infuser(event, <Input item>, <Output item>, <Duration (100 by default)>, <Consumption chance (float, 0.1 by default)>, [>Consume multiple fluids (False by default)>, <Accept chalice input (True by default)>, <Copy NBT to output (False by default)>](Array can contain any number of booleans), <Input fluid id name ("astralsorcery:liquid_starlight" by default)>, <id>)
+global.mrt.astralsorcery.infuser(event, <Input item>, <Output item>, <Duration (100 by default)>, <Consumption chance (float, 0.1 by default)>, [>Consume multiple fluids (False by default)>, <Accept chalice input (True by default)>, <Copy NBT to output (False by default)>](Array can contain any number of booleans), <Input fluid id name ("astralsorcery:liquid_starlight" by default)>, <id>)
 ```
 
 #### Lightwell
 
 ```js
-global.more_recipe_types.astralsorcery.lightwell(event, <Input item>, <Output fluid id name>, <Production multiplier (float, 1 by default)>, <Shatter multiplier (float, lower = faster shatter, 10 by default)>, <color (white color by default)>, <id>)
+global.mrt.astralsorcery.lightwell(event, <Input item>, <Output fluid id name>, <Production multiplier (float, 1 by default)>, <Shatter multiplier (float, lower = faster shatter, 10 by default)>, <color (white color by default)>, <id>)
 ```
 
 #### Liquid Interaction
 
 ```js
-global.more_recipe_types.astralsorcery.liquid_interaction(event, [Fluid.of(<Input fluid 1>, <Amount>), <Chance consume fluid 1 (float, 100% by default)>], [Fluid.of(<Input fluid 2>, <Amount>), <Chance consume fluid 2 (float, 100% by default)>], <Output item>, <weight (1 by default)>, <id>)
+global.mrt.astralsorcery.liquid_interaction(event, [Fluid.of(<Input fluid 1>, <Amount>), <Chance consume fluid 1 (float, 100% by default)>], [Fluid.of(<Input fluid 2>, <Amount>), <Chance consume fluid 2 (float, 100% by default)>], <Output item>, <weight (1 by default)>, <id>)
 ```  
 
 ### Atum
@@ -85,19 +85,19 @@ global.more_recipe_types.astralsorcery.liquid_interaction(event, [Fluid.of(<Inpu
 #### Kiln
 
 ```js
-global.more_recipe_types.atum.kiln(event, <Input item>, <Output item>, <Experience (float, 0.1 by default)>, <id>)
+global.mrt.atum.kiln(event, <Input item>, <Output item>, <Experience (float, 0.1 by default)>, <id>)
 ```
 
 #### Quern
 
 ```js
-global.more_recipe_types.atum.quern(event, <Input item>, <Output item>, <Rotations (1 by default)>, <id>)
+global.mrt.atum.quern(event, <Input item>, <Output item>, <Rotations (1 by default)>, <id>)
 ```
 
 #### Spinning Wheel
 
 ```js
-global.more_recipe_types.atum.spinning_wheel(event, <Input item>, <Output item>, <Rotations (1 by default)>, <id>)
+global.mrt.atum.spinning_wheel(event, <Input item>, <Output item>, <Rotations (1 by default)>, <id>)
 ```
 
 ### Better End Forge
@@ -105,19 +105,19 @@ global.more_recipe_types.atum.spinning_wheel(event, <Input item>, <Output item>,
 #### Alloying
 
 ```js
-global.more_recipe_types.betterendforge.alloying(event, [<Input items>], <Output item>, <Experience (float, 1 by default)>, <Time in ticks (200 by default)>, <id>)
+global.mrt.betterendforge.alloying(event, [<Input items>], <Output item>, <Experience (float, 1 by default)>, <Time in ticks (200 by default)>, <id>)
 ```
 
 #### Anvil Smithing
 
 ```js
-global.more_recipe_types.betterendforge.anvil_smithing(event, <Input item>, <Output item>, <Tool level (0 by default = wood/gold)>, <Anvil level (1 by default)>, <Damage to tool (1 by default)>, <id>)
+global.mrt.betterendforge.anvil_smithing(event, <Input item>, <Output item>, <Tool level (0 by default = wood/gold)>, <Anvil level (1 by default)>, <Damage to tool (1 by default)>, <id>)
 ```
 
 #### Infusion
 
 ```js
-global.more_recipe_types.betterendforge.infusion(event, <Middle Input item>, [<Catalyst Input items (clockwise from top middle)>], <Output item>, <Time in seconds (100 by default)>, <id>)
+global.mrt.betterendforge.infusion(event, <Middle Input item>, [<Catalyst Input items (clockwise from top middle)>], <Output item>, <Time in seconds (100 by default)>, <id>)
 ```
 
 ### (Space) Boss Tools
@@ -125,13 +125,13 @@ global.more_recipe_types.betterendforge.infusion(event, <Middle Input item>, [<C
 #### Blasting
 
 ```js
-global.more_recipe_types.boss_tools.blasting(event, <Input item>, <Output item>, <Cook time (200 by default)>, <id>)
+global.mrt.boss_tools.blasting(event, <Input item>, <Output item>, <Cook time (200 by default)>, <id>)
 ```
 
 #### Compressing
 
 ```js
-global.more_recipe_types.boss_tools.compressing(event, <Input item>, <Output item>, <Cook time (200 by default)>, <id>)
+global.mrt.boss_tools.compressing(event, <Input item>, <Output item>, <Cook time (200 by default)>, <id>)
 ```
 
 ### Botania
@@ -139,43 +139,43 @@ global.more_recipe_types.boss_tools.compressing(event, <Input item>, <Output ite
 #### Brew (Botanical Brewery)
 
 ```js
-global.more_recipe_types.botania.brew(event, [<Input items>], <Output Brew id name (example: "botania:haste")>, <id>)
+global.mrt.botania.brew(event, [<Input items>], <Output Brew id name (example: "botania:haste")>, <id>)
 ```
 
 #### Elven Trade
 
 ```js
-global.more_recipe_types.botania.elven_trade(event, [<Input items>], [<Output items>], <id>)
+global.mrt.botania.elven_trade(event, [<Input items>], [<Output items>], <id>)
 ```
 
 #### Mana Infusion
 
 ```js
-global.more_recipe_types.botania.mana_infusion(event, <Output items>, <Output item>, <Mana (1000 by default)>, "Catalyst", <id>)
+global.mrt.botania.mana_infusion(event, <Output items>, <Output item>, <Mana (1000 by default)>, "Catalyst", <id>)
 ```
 
 #### Petal Aplothecary
 
 ```js
-global.more_recipe_types.botania.petal_apothecary(event, [<Input items>], <Output item>, <id>)
+global.mrt.botania.petal_apothecary(event, [<Input items>], <Output item>, <id>)
 ```
 
 #### Pure Daisy
 
 ```js
-global.more_recipe_types.botania.pure_daisy(event, <Input block>, <Output block>)
+global.mrt.botania.pure_daisy(event, <Input block>, <Output block>)
 ```
 
 #### Runic Altar
 
 ```js
-global.more_recipe_types.botania.runic_altar(event, [<Input items>], <Output item>, <Mana (5000 by default)>, <id>)
+global.mrt.botania.runic_altar(event, [<Input items>], <Output item>, <Mana (5000 by default)>, <id>)
 ```
 
 #### Terra Plate (Terrestrial Agglomeration)
 
 ```js
-global.more_recipe_types.botania.terra_plate(event, [<Input items>], <Output item>, <Mana (100000 by default)>, <id>)
+global.mrt.botania.terra_plate(event, [<Input items>], <Output item>, <Mana (100000 by default)>, <id>)
 ```
 
 ### Botany Pots
@@ -183,19 +183,19 @@ global.more_recipe_types.botania.terra_plate(event, [<Input items>], <Output ite
 #### Crop
 
 ```js
-global.more_recipe_types.botanypots.crop(event, <Input seed>, [<Soil categories>], [[<Output item>, <Chance (float, 1 by default)>, <Min rolls (1 by default)>, <Max Rolls (1 by default)>], ...], <Growth ticks (1200 by default)>, <Display block (Input seed by default. Change if seed is item!)>, <id>)
+global.mrt.botanypots.crop(event, <Input seed>, [<Soil categories>], [[<Output item>, <Chance (float, 1 by default)>, <Min rolls (1 by default)>, <Max Rolls (1 by default)>], ...], <Growth ticks (1200 by default)>, <Display block (Input seed by default. Change if seed is item!)>, <id>)
 ```
 
 #### Fertilizer
 
 ```js
-global.more_recipe_types.botanypots.fertilizer(event, <Input Fertilizer>, <Min ticks (100 by default)>, <Max ticks (Min ticks + 100 by default)>, <id>)
+global.mrt.botanypots.fertilizer(event, <Input Fertilizer>, <Min ticks (100 by default)>, <Max ticks (Min ticks + 100 by default)>, <id>)
 ```
 
 #### Soil
 
 ```js
-global.more_recipe_types.botanypots.soil(event, <Input soil>, [<Soil categories>], <Growth modifier (float between -1 and 1, 0 by default)>, <Display block (Input soil by default. Change if soil is item!)>, <id>)
+global.mrt.botanypots.soil(event, <Input soil>, [<Soil categories>], <Growth modifier (float between -1 and 1, 0 by default)>, <Display block (Input soil by default. Change if soil is item!)>, <id>)
 ```
 
 ### Draconic Evolution
@@ -203,7 +203,7 @@ global.more_recipe_types.botanypots.soil(event, <Input soil>, [<Soil categories>
 #### Fusion Crafting
 
 ```js
-global.more_recipe_types.draconicevolution.fusion_crafting(event, <Main input item>, [<side Input items>], <Output item>, <Tier (of DRACONIUM = default, WYVERN, DRACONIC, CHAOTIC)>, <Energy (100000 by default)>, <id>)
+global.mrt.draconicevolution.fusion_crafting(event, <Main input item>, [<side Input items>], <Output item>, <Tier (of DRACONIUM = default, WYVERN, DRACONIC, CHAOTIC)>, <Energy (100000 by default)>, <id>)
 ```
 
 ### DivineRPG
@@ -211,13 +211,13 @@ global.more_recipe_types.draconicevolution.fusion_crafting(event, <Main input it
 #### Infusion Table
 
 ```js
-global.more_recipe_types.divinerpg.infusion_table(event, <Input item>, <Input template>, <Output item>, <id>)
+global.mrt.divinerpg.infusion_table(event, <Input item>, <Input template>, <Output item>, <id>)
 ```
 
 #### Fusion Crafting
 
 ```js
-global.more_recipe_types.draconicevolution.fusion_crafting(event, <Main input item>, [<side Input items>], <Output item>, <Tier (of DRACONIUM = default, WYVERN, DRACONIC, CHAOTIC)>, <Energy (100000 by default)>, <id>)
+global.mrt.draconicevolution.fusion_crafting(event, <Main input item>, [<side Input items>], <Output item>, <Tier (of DRACONIUM = default, WYVERN, DRACONIC, CHAOTIC)>, <Energy (100000 by default)>, <id>)
 ```
 
 ### Elemental Craft
@@ -225,49 +225,49 @@ global.more_recipe_types.draconicevolution.fusion_crafting(event, <Main input it
 #### Binding (Element Binding)
 
 ```js
-global.more_recipe_types.elementalcraft.binding(event, [<Input items>], <Output item>, <Element Type>, <Element Amount (1000 by default)>, <id>)
+global.mrt.elementalcraft.binding(event, [<Input items>], <Output item>, <Element Type>, <Element Amount (1000 by default)>, <id>)
 ```
 
 #### Crystallization (Gem Crystallization)
 
 ```js
-global.more_recipe_types.elementalcraft.crystallization(event, [<Gem input item>, <Crystal input item>, <Shard input item>], [[<Output item>, <Weight (1 by default)>, <Quality (null by default)>], ...], <Element Type>, <Element Amount (1000 by default)>, <id>)
+global.mrt.elementalcraft.crystallization(event, [<Gem input item>, <Crystal input item>, <Shard input item>], [[<Output item>, <Weight (1 by default)>, <Quality (null by default)>], ...], <Element Type>, <Element Amount (1000 by default)>, <id>)
 ```
 
 #### Grinding
 
 ```js
-global.more_recipe_types.elementalcraft.grinding(event, <Input item>, <Output item>, <Element Amount (1000 by default)>, <id>)
+global.mrt.elementalcraft.grinding(event, <Input item>, <Output item>, <Element Amount (1000 by default)>, <id>)
 ```
 
 #### Tool Infusion (Element Infusion)
 
 ```js
-global.more_recipe_types.elementalcraft.tool_infusion(event, <Input item>, <Tool infusion type (e.g.: "elementalcraft:fire_aspect")>, <Element Amount (1000 by default)>, <id>)
+global.mrt.elementalcraft.tool_infusion(event, <Input item>, <Tool infusion type (e.g.: "elementalcraft:fire_aspect")>, <Element Amount (1000 by default)>, <id>)
 ```
 
 #### Infusion (Element Infusion)
 
 ```js
-global.more_recipe_types.elementalcraft.infusion(event, <Input item>, <Output Item>, <Element Type>, <Element Amount (1000 by default)>, <id>)
+global.mrt.elementalcraft.infusion(event, <Input item>, <Output Item>, <Element Type>, <Element Amount (1000 by default)>, <id>)
 ```
 
 #### Inscription (Rune Inscription)
 
 ```js
-global.more_recipe_types.elementalcraft.inscription(event, [<Slate input item>, <3 other input items>], [<Output item>, <nbt>], <Element Type>, <Element Amount (1000 by default)>, <id>)
+global.mrt.elementalcraft.inscription(event, [<Slate input item>, <3 other input items>], [<Output item>, <nbt>], <Element Type>, <Element Amount (1000 by default)>, <id>)
 ```
 
 #### Pure Infusion
 
 ```js
-global.more_recipe_types.elementalcraft.pureinfusion(event, [<middle input item>, <Water input item>, <Fire input item>, <Earth input item>, <Air input item>], <Output Item>, <Element Amount (1000 by default)>, <id>)
+global.mrt.elementalcraft.pureinfusion(event, [<middle input item>, <Water input item>, <Fire input item>, <Earth input item>, <Air input item>], <Output Item>, <Element Amount (1000 by default)>, <id>)
 ```
 
 #### Spell Craft
 
 ```js
-global.more_recipe_types.elementalcraft.spell_craft(event, [<Gem input item>, <Crystal input item>], [<Output item>, <nbt>], <id>)
+global.mrt.elementalcraft.spell_craft(event, [<Gem input item>, <Crystal input item>], [<Output item>, <nbt>], <id>)
 ```
 
 ### Evil Craft
@@ -275,13 +275,13 @@ global.more_recipe_types.elementalcraft.spell_craft(event, [<Gem input item>, <C
 #### Blood Infuser
 
 ```js
-global.more_recipe_types.evilcraft.blood_infuser(event, <Input item>, Fluid.of(<Input fluid>, <Amount>), <Output item>, <Tier (0-3, 0 by default)>, <time in ticks (200 by default)>, <Experience (float, 0.1 by default)>, <id>)
+global.mrt.evilcraft.blood_infuser(event, <Input item>, Fluid.of(<Input fluid>, <Amount>), <Output item>, <Tier (0-3, 0 by default)>, <time in ticks (200 by default)>, <Experience (float, 0.1 by default)>, <id>)
 ```
 
 #### Environmental Accumulator / Sanguinary Environmental Accumulator
 
 ```js
-global.more_recipe_types.evilcraft.environmental_accumulator(event, <Input item>, <Input action (e.g. LIGHTNING)>, <Output item>, <Output weather (ANY, CLEAR, RAIN, LIGHTNING)>, <time in ticks (100 by default)>, <Cooldown time in ticks (0 by default)>, <id>)
+global.mrt.evilcraft.environmental_accumulator(event, <Input item>, <Input action (e.g. LIGHTNING)>, <Output item>, <Output weather (ANY, CLEAR, RAIN, LIGHTNING)>, <time in ticks (100 by default)>, <Cooldown time in ticks (0 by default)>, <id>)
 ```
 
 ### FTB Industrial Contraptions
@@ -289,13 +289,13 @@ global.more_recipe_types.evilcraft.environmental_accumulator(event, <Input item>
 #### Antimatter Boost
 
 ```js
-global.more_recipe_types.ftbic.antimatter_boost(event, <Input item>, <Boost (1000 by default)>, <id>)
+global.mrt.ftbic.antimatter_boost(event, <Input item>, <Boost (1000 by default)>, <id>)
 ```
 
 #### Basic Generator Fuel
 
 ```js
-global.more_recipe_types.ftbic.basic_generator_fuel(event, <Input item>, <Burn ticks (1 tick = 10 zaps, 200 by default)>, <id>)
+global.mrt.ftbic.basic_generator_fuel(event, <Input item>, <Burn ticks (1 tick = 10 zaps, 200 by default)>, <id>)
 ```
 
 #### Other Machines
@@ -310,7 +310,7 @@ Supported types:
 - seperating
 
 ```js
-global.more_recipe_types.ftbic.<type>(event, [<Input items>], [<Output Items>], <id>)
+global.mrt.ftbic.<type>(event, [<Input items>], [<Output Items>], <id>)
 ```
 
 Some notes:
@@ -323,25 +323,25 @@ Some notes:
 #### Dissolution Chamber
 
 ```js
-global.more_recipe_types.industrialforegoing.dissolution_chamber(event, [<Input items>], Fluid.of(<Input fluid>, <Amount>), <Output item>, <Output fluid (nothing by default)>, <Time in ticks (20 by default)>, <id>)
+global.mrt.industrialforegoing.dissolution_chamber(event, [<Input items>], Fluid.of(<Input fluid>, <Amount>), <Output item>, <Output fluid (nothing by default)>, <Time in ticks (20 by default)>, <id>)
 ```
 
 #### Fluid Extractor
 
 ```js
-global.more_recipe_types.industrialforegoing.fluid_extractor(event, <Input block>, Fluid.of(<Output fluid>, <Amount>), <Block damage chance (float, 0% by default)>, <Result block ("minecraft:air" by default)>, <id>)
+global.mrt.industrialforegoing.fluid_extractor(event, <Input block>, Fluid.of(<Output fluid>, <Amount>), <Block damage chance (float, 0% by default)>, <Result block ("minecraft:air" by default)>, <id>)
 ```
 
 #### Laser Drill (Ore / Fluid)
 
 ```js
-global.more_recipe_types.industrialforegoing.laser_drill(event, <Output item / Fluid.of(<Output Fluid>, <Amount>)>, <Catalyst Item>, [[[[<List values (empty by default)>], <List Blacklist ? (else whitelist, false by default)>, <List type ("minecraft:worldgen/biome" by default)>], [<Min depth (0 by default)>, <Max depth (64 by default)>], <Weight (1 by default)>], ...], <Fluid recipe ? (false by default)>, <Entity (only if Fluid recipe, no entity by default)>, <id>)
+global.mrt.industrialforegoing.laser_drill(event, <Output item / Fluid.of(<Output Fluid>, <Amount>)>, <Catalyst Item>, [[[[<List values (empty by default)>], <List Blacklist ? (else whitelist, false by default)>, <List type ("minecraft:worldgen/biome" by default)>], [<Min depth (0 by default)>, <Max depth (64 by default)>], <Weight (1 by default)>], ...], <Fluid recipe ? (false by default)>, <Entity (only if Fluid recipe, no entity by default)>, <id>)
 ```
 
 #### Stonework Generate
 
 ```js
-global.more_recipe_types.industrialforegoing.stonework_generate(event, <Output Item>, [<Water requirement (1000 by default)>, <Water usage (0 by default)>], [<Lava requirement (1000 by default)>, <Lava usage (0 by default)>], <id>)
+global.mrt.industrialforegoing.stonework_generate(event, <Output Item>, [<Water requirement (1000 by default)>, <Water usage (0 by default)>], [<Lava requirement (1000 by default)>, <Lava usage (0 by default)>], <id>)
 ```
 
 ### Mystical Agriculture
@@ -349,19 +349,19 @@ global.more_recipe_types.industrialforegoing.stonework_generate(event, <Output I
 #### Infusion (Crafting)
 
 ```js
-global.more_recipe_types.mysticalagriculture.infusion(event, <Middle input item>, [<Side input items>], <Output item>, <id>)
+global.mrt.mysticalagriculture.infusion(event, <Middle input item>, [<Side input items>], <Output item>, <id>)
 ```
 
 #### (Seed) Reprocessing
 
 ```js
-global.more_recipe_types.mysticalagriculture.reprocessor(event, <Input item>, <Output item>, <id>)
+global.mrt.mysticalagriculture.reprocessor(event, <Input item>, <Output item>, <id>)
 ```
 
 #### Soul Extraction
 
 ```js
-global.more_recipe_types.mysticalagriculture.soul_extraction(event, <Input item>, <Soul type (e.g. "mysticalagriculture:skeleton")>, <Soul amount (1 by default)>, <id>)
+global.mrt.mysticalagriculture.soul_extraction(event, <Input item>, <Soul type (e.g. "mysticalagriculture:skeleton")>, <Soul amount (1 by default)>, <id>)
 ```
 
 ### PneumaticCraft: Repressurized
@@ -369,61 +369,61 @@ global.more_recipe_types.mysticalagriculture.soul_extraction(event, <Input item>
 #### Amadron (Amadron Tablet)
 
 ```js
-global.more_recipe_types.pneumaticcraft.amadron(event, [<Input item / Fluid.of(<Input fluid>, <Amount>)>, <Input is Fluid ? (false by default)>], [<Output item / Fluid.of(<Output fluid>, <Amount>)>, <Output is Fluid ? (false by default)>], <id>)
+global.mrt.pneumaticcraft.amadron(event, [<Input item / Fluid.of(<Input fluid>, <Amount>)>, <Input is Fluid ? (false by default)>], [<Output item / Fluid.of(<Output fluid>, <Amount>)>, <Output is Fluid ? (false by default)>], <id>)
 ```
 
 #### Assembly Laser (Assembly Controller)
 
 ```js
-global.more_recipe_types.pneumaticcraft.assembly_laser(event, <Input item>, <Output item>, <Type is Drill ? (false by default)>, <id>)
+global.mrt.pneumaticcraft.assembly_laser(event, <Input item>, <Output item>, <Type is Drill ? (false by default)>, <id>)
 ```
 
 #### Explosion Crafting
 
 ```js
-global.more_recipe_types.pneumaticcraft.explosion_crafting(event, <Input item>, [<Output items>], <Loss rate (0 - 100, 20 by default)>, <id>)
+global.mrt.pneumaticcraft.explosion_crafting(event, <Input item>, [<Output items>], <Loss rate (0 - 100, 20 by default)>, <id>)
 ```
 
 #### Heat Frame Cooling
 
 ```js
-global.more_recipe_types.pneumaticcraft.heat_frame_cooling(event, [<Input fluid>, <Amount>], <Output item>, <Max temperature (0°C by default)>, [<Bonus output multiplier per degree (0 by default)>, <Bonus output max multiplier (0 by default)>], <id>)
+global.mrt.pneumaticcraft.heat_frame_cooling(event, [<Input fluid>, <Amount>], <Output item>, <Max temperature (0°C by default)>, [<Bonus output multiplier per degree (0 by default)>, <Bonus output max multiplier (0 by default)>], <id>)
 ```
 
 #### (Block) Heat Properties
 
 ```js
-global.more_recipe_types.pneumaticcraft.heat_properties(event, <Input block>, [<Output block from Cooling>, <Output block from Heating>], <Block temperature (25°C by default)>, <Thermal Resictance (20 by default)>, <Heat Capacity (1000 by default)>, <id>)
+global.mrt.pneumaticcraft.heat_properties(event, <Input block>, [<Output block from Cooling>, <Output block from Heating>], <Block temperature (25°C by default)>, <Thermal Resictance (20 by default)>, <Heat Capacity (1000 by default)>, <id>)
 ```
 
 #### Fluid Mixer
 
 ```js
-global.more_recipe_types.pneumaticcraft.fluid_mixer(event, [<Input Fluid 1>, <Amount (1000 by default)>], <Input Fluid 2>, <Amount (1000 by default)>], Fluid.of(<Output Fluid>, <Amount>), <Output item>, <Pressure (1 by default)>, <Time in ticks (200 by default)>, <id>)
+global.mrt.pneumaticcraft.fluid_mixer(event, [<Input Fluid 1>, <Amount (1000 by default)>], <Input Fluid 2>, <Amount (1000 by default)>], Fluid.of(<Output Fluid>, <Amount>), <Output item>, <Pressure (1 by default)>, <Time in ticks (200 by default)>, <id>)
 ```
 
 #### Fuel Quality
 
 ```js
-global.more_recipe_types.pneumaticcraft.fuel_quality(event, <Input fluid>, <Air per bucket (100000 by default)>, <Burn rate (float, 1 by default)>, <id>)
+global.mrt.pneumaticcraft.fuel_quality(event, <Input fluid>, <Air per bucket (100000 by default)>, <Burn rate (float, 1 by default)>, <id>)
 ```
 
 #### Pressure Chamber
 
 ```js
-global.more_recipe_types.pneumaticcraft.pressure_chamber(event, [<Input items>], [<Output items>], <Pressure (1 by default)>, <id>)
+global.mrt.pneumaticcraft.pressure_chamber(event, [<Input items>], [<Output items>], <Pressure (1 by default)>, <id>)
 ```
 
 #### Refinery (Refinery Controller)
 
 ```js
-global.more_recipe_types.pneumaticcraft.refinery(event, [<Input fluid>, <Amount (1000 by default)>], [Fluid.of(<Output Fluid>, <Amount>), ... (atleast two fluids)], [<Min temperature>, <Max temperature>], <id>)
+global.mrt.pneumaticcraft.refinery(event, [<Input fluid>, <Amount (1000 by default)>], [Fluid.of(<Output Fluid>, <Amount>), ... (atleast two fluids)], [<Min temperature>, <Max temperature>], <id>)
 ```
 
 #### Thermo Plant (Thermopneumatic Processing Plant)
 
 ```js
-global.more_recipe_types.pneumaticcraft.thermo_plant(event, <Input item>, [<Input fluid>, <Amount>], <Output item>, Fluid.of(<Ouput fluid>, <Amount>), [<Min temperature>, <Max temperature>], <Pressure>, <Speed (float, 1 by default)>, <is Exothermic ? (false by default)>, <id>)   
+global.mrt.pneumaticcraft.thermo_plant(event, <Input item>, [<Input fluid>, <Amount>], <Output item>, Fluid.of(<Ouput fluid>, <Amount>), [<Min temperature>, <Max temperature>], <Pressure>, <Speed (float, 1 by default)>, <is Exothermic ? (false by default)>, <id>)   
 ```
 
 ### Powah
@@ -431,7 +431,7 @@ global.more_recipe_types.pneumaticcraft.thermo_plant(event, <Input item>, [<Inpu
 #### Energizing
 
 ```js
-global.more_recipe_types.powah.energizing(event, [<Input items>], <Output item>, <Energy (100 by default)>, <id>)
+global.mrt.powah.energizing(event, [<Input items>], <Output item>, <Energy (100 by default)>, <id>)
 ```
 
 ### Psi
@@ -439,7 +439,7 @@ global.more_recipe_types.powah.energizing(event, [<Input items>], <Output item>,
 #### Trick Crafting (Spell Infusion)
 
 ```js
-global.more_recipe_types.psi.trick_crafting(event, <Input item>, <Output item>, <Cad assemby>, <Trick>, <Dimension (Isn't listed in JEI)>, <id>)
+global.mrt.psi.trick_crafting(event, <Input item>, <Output item>, <Cad assemby>, <Trick>, <Dimension (Isn't listed in JEI)>, <id>)
 ```
 
 ### Silent Gear
@@ -447,13 +447,13 @@ global.more_recipe_types.psi.trick_crafting(event, <Input item>, <Output item>, 
 #### Compounding
 
 ```js
-global.more_recipe_types.silentgear.compounding(event, [<Input items>], <Output item>, <Gem Compounding ? (else Metal, false by default)>, <id>)
+global.mrt.silentgear.compounding(event, [<Input items>], <Output item>, <Gem Compounding ? (else Metal, false by default)>, <id>)
 ```
 
 #### Salvaging
 
 ```js
-global.more_recipe_types.silentgear.salvaging(event, <Input item>, [<Output items>], <id>)
+global.mrt.silentgear.salvaging(event, <Input item>, [<Output items>], <id>)
 ```
 
 ### Silent's Mechanism's
@@ -461,49 +461,49 @@ global.more_recipe_types.silentgear.salvaging(event, <Input item>, [<Output item
 #### Alloy Smelting
 
 ```js
-global.more_recipe_types.silents_mechanisms.alloy_smelting(event, [[[<Input item>, ...], <Amount>], ...], <Output item>, <Time in ticks (200 by default)>, <id>)
+global.mrt.silents_mechanisms.alloy_smelting(event, [[[<Input item>, ...], <Amount>], ...], <Output item>, <Time in ticks (200 by default)>, <id>)
 ```
 
 #### Compressing
 
 ```js
-global.more_recipe_types.silents_mechanisms.compressing(event, [[<Input item>, ...], <Amount>], <Output item>, <Time in ticks (200 by default)>, <id>)
+global.mrt.silents_mechanisms.compressing(event, [[<Input item>, ...], <Amount>], <Output item>, <Time in ticks (200 by default)>, <id>)
 ```
 
 #### Crushing
 
 ```js
-global.more_recipe_types.silents_mechanisms.crushing(event, <Input item>, [<Output items>], <Time in ticks (200 by default)>, <id>)
+global.mrt.silents_mechanisms.crushing(event, <Input item>, [<Output items>], <Time in ticks (200 by default)>, <id>)
 ```
 
 #### Drying
 
 ```js
-global.more_recipe_types.silents_mechanisms.drying(event, <Input item>, <Output item>, <Time in ticks (200 by default)>, <id>)
+global.mrt.silents_mechanisms.drying(event, <Input item>, <Output item>, <Time in ticks (200 by default)>, <id>)
 ```
 
 #### Infusing
 
 ```js
-global.more_recipe_types.silents_mechanisms.infusing(event, <Input item>, [<Input fluid>, <Amount (1000 by default)>], <Output item>, <Time in ticks (200 by default)>, <id>)
+global.mrt.silents_mechanisms.infusing(event, <Input item>, [<Input fluid>, <Amount (1000 by default)>], <Output item>, <Time in ticks (200 by default)>, <id>)
 ```
 
 #### Mixing
 
 ```js
-global.more_recipe_types.silents_mechanisms.mixing(event, [[<Input fluid>, <Amount (1000 by default)>], ...], Fluid.of(<Output fluid>, <Amount>), <Time in ticks (200 by default)>, <id>)
+global.mrt.silents_mechanisms.mixing(event, [[<Input fluid>, <Amount (1000 by default)>], ...], Fluid.of(<Output fluid>, <Amount>), <Time in ticks (200 by default)>, <id>)
 ```
 
 #### Refining
 
 ```js
-global.more_recipe_types.silents_mechanisms.refining(event, [<Input fluid>, <Amount (1000 by default)>], [Fluid.of(<Output fluid>, <Amount>), ...], <Time in ticks (200 by default)>, <id>)
+global.mrt.silents_mechanisms.refining(event, [<Input fluid>, <Amount (1000 by default)>], [Fluid.of(<Output fluid>, <Amount>), ...], <Time in ticks (200 by default)>, <id>)
 ```
 
 #### Solidifying
 
 ```js
-global.more_recipe_types.silents_mechanisms.solidifying(event, [<Input fluid>, <Amount (1000 by default)>], <Output item>, <Time in ticks (200 by default)>, <id>)
+global.mrt.silents_mechanisms.solidifying(event, [<Input fluid>, <Amount (1000 by default)>], <Output item>, <Time in ticks (200 by default)>, <id>)
 ```
 
 ### Tinker's Construct
@@ -511,47 +511,47 @@ global.more_recipe_types.silents_mechanisms.solidifying(event, [<Input fluid>, <
 #### Alloy (Alloying)
 
 ```js
-global.more_recipe_types.tconstruct.alloy(event, [[<Input fluid>, <Amount (1000 by default)>], ...], Fluid.of(<Output fluid>, <Amount>), <Temperature (100 by default)>, <id>)
+global.mrt.tconstruct.alloy(event, [[<Input fluid>, <Amount (1000 by default)>], ...], Fluid.of(<Output fluid>, <Amount>), <Temperature (100 by default)>, <id>)
 ```
 
 #### Casting (Table / Basin)
 
 ```js
-global.more_recipe_types.tconstruct.casting(event, [<Input fluid>, <Amount (1000 by default)>], <Input Cast>, <Output item>, <Basin ? (else table, false by default)>, <Cast consumed ? (false by default)>, <Time in ticks (60 by default)>, <id>)
+global.mrt.tconstruct.casting(event, [<Input fluid>, <Amount (1000 by default)>], <Input Cast>, <Output item>, <Basin ? (else table, false by default)>, <Cast consumed ? (false by default)>, <Time in ticks (60 by default)>, <id>)
 ```
 
 #### Entity Melting
 
 ```js
-global.more_recipe_types.tconstruct.entity_melting(event, <Entity>, Fluid.of(<Output fluid>, <Amount>), <Damage (1 by default)>, <id>)
+global.mrt.tconstruct.entity_melting(event, <Entity>, Fluid.of(<Output fluid>, <Amount>), <Damage (1 by default)>, <id>)
 ```
 
 #### Melting
 
 ```js
-global.more_recipe_types.tconstruct.melting(event, <Input item>, Fluid.of(<Output fluid>, <Amount>), <Temperature (100 by default)>, <Time in ticks (300 by default)>, <id>)
+global.mrt.tconstruct.melting(event, <Input item>, Fluid.of(<Output fluid>, <Amount>), <Temperature (100 by default)>, <Time in ticks (300 by default)>, <id>)
 ```
 
 #### Molding (Table)
 
 ```js
-global.more_recipe_types.tconstruct.molding_table(event, <Input Cast>, <Input item>, <Output cast>, <id>)
+global.mrt.tconstruct.molding_table(event, <Input Cast>, <Input item>, <Output cast>, <id>)
 ```
 
 #### Part Builder
 
 ```js
-global.more_recipe_types.tconstruct.part_builder(event, <Input pattern>, <Output Part>, <Cost (1 by default)>, <id>)
+global.mrt.tconstruct.part_builder(event, <Input pattern>, <Output Part>, <Cost (1 by default)>, <id>)
 ```
 
 #### Severing
 
 ```js
-global.more_recipe_types.tconstruct.severing(event, <Entity>, <Output item>, <id>)
+global.mrt.tconstruct.severing(event, <Entity>, <Output item>, <id>)
 ```
 
 #### Casting Table with Parts (like Part Builder)
 
 ```js
-global.more_recipe_types.tconstruct.table_casting_material(event, <Input cast>, <Output Part>, <Cost (1 by default)>, <id>)
+global.mrt.tconstruct.table_casting_material(event, <Input cast>, <Output Part>, <Cost (1 by default)>, <id>)
 ```

--- a/README.md
+++ b/README.md
@@ -234,6 +234,67 @@ global.more_recipe_types.industrialforegoing.laser_drill(event, <Output item / F
 global.more_recipe_types.industrialforegoing.stonework_generate(event, <Output Item>, [<Water requirement (1000 by default)>, <Water usage (0 by default)>], [<Lava requirement (1000 by default)>, <Lava usage (0 by default)>])
 ```
 
+### PneumaticCraft: Repressurized
+
+#### Amadron (Amadron Tablet)
+
+```js
+global.more_recipe_types.pneumaticcraft.amadron(event, [<Input item / Fluid.of(<Input fluid>, <Amount>)>, <Input is Fluid ? (false by default)>], [<Output item / Fluid.of(<Output fluid>, <Amount>)>, <Output is Fluid ? (false by default)>])
+```
+
+#### Assembly Laser (Assembly Controller)
+
+```js
+global.more_recipe_types.pneumaticcraft.assembly_laser(event, <Input item>, <Output item>, <Type is Drill ? (false by default)>)
+```
+
+#### Explosion Crafting
+
+```js
+global.more_recipe_types.pneumaticcraft.explosion_crafting(event, <Input item>, [<Output items>], <Loss rate (0 - 100, 20 by default)>)
+```
+
+#### Heat Frame Cooling
+
+```js
+global.more_recipe_types.pneumaticcraft.heat_frame_cooling(event, [<Input fluid>, <Amount>], <Output item>, <Max temperature (0°C by default)>, [<Bonus output multiplier per degree (0 by default)>, <Bonus output max multiplier (0 by default)>])
+```
+
+#### (Block) Heat Properties
+```js
+global.more_recipe_types.pneumaticcraft.heat_properties(event, <Input block>, [<Output block from Cooling>, <Output block from Heating>], <Block temperature (25°C by default)>, <Thermal Resictance (20 by default)>, <Heat Capacity (1000 by default)>)
+```
+
+#### Fluid Mixer´
+
+```js
+global.more_recipe_types.pneumaticcraft.fluid_mixer(event, [<Input Fluid 1>, <Amount (1000 by default)>], <Input Fluid 2>, <Amount (1000 by default)>], Fluid.of(<Output Fluid>, <Amount>), <Output item>, <Pressure (1 by default)>, <Time in ticks (200 by default)>)
+```
+
+#### Fuel Quality
+
+```js
+global.more_recipe_types.pneumaticcraft.fuel_quality(event, <Input fluid>, <Air per bucket (100000 by default)>, <Burn rate (float, 1 by default)>)
+```
+
+#### Pressure Chamber
+
+```js
+global.more_recipe_types.pneumaticcraft.pressure_chamber(event, [<Input items>], [<Output items>], <Pressure (1 by default)>)
+```
+
+#### Refinery (Refinery Controller)
+
+```js
+global.more_recipe_types.pneumaticcraft.refinery(event, [<Input fluid>, <Amount (1000 by default)>], [Fluid.of(<Output Fluid>, <Amount>), ... (atleast two fluids)], [<Min temperature>, <Max temperature>])
+```
+
+#### Thermo Plant (Thermopneumatic Processing Plant)
+
+```js
+global.more_recipe_types.pneumaticcraft.thermo_plant(event, <Input item>, [<Input fluid>, <Amount>], <Output item>, Fluid.of(<Ouput fluid>, <Amount>), [<Min temperature>, <Max temperature>], <Pressure>, <Speed (float, 1 by default)>, <is Exothermic ? (false by default)>)   
+```
+
 ### Powah
 
 #### Energizing

--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ global.more_recipe_types.ftbic.<type>(event, [<Input items>], [<Output Items>])
 
 Some notes:
 
-- To use nbt in input items use Item.of(<Input item>, <nbt>)
-- To use chance in output items use Item.of(<Input item>).withChance(<Chance>)
+- To use nbt in input items use Item.of("<Input item>", "<nbt>")
+- To use chance in output items use Item.of("<Input item>").withChance("<Chance>")
 
 ### Industrial Foregoing
 
@@ -261,11 +261,12 @@ global.more_recipe_types.pneumaticcraft.heat_frame_cooling(event, [<Input fluid>
 ```
 
 #### (Block) Heat Properties
+
 ```js
 global.more_recipe_types.pneumaticcraft.heat_properties(event, <Input block>, [<Output block from Cooling>, <Output block from Heating>], <Block temperature (25°C by default)>, <Thermal Resictance (20 by default)>, <Heat Capacity (1000 by default)>)
 ```
 
-#### Fluid Mixer´
+#### Fluid Mixer
 
 ```js
 global.more_recipe_types.pneumaticcraft.fluid_mixer(event, [<Input Fluid 1>, <Amount (1000 by default)>], <Input Fluid 2>, <Amount (1000 by default)>], Fluid.of(<Output Fluid>, <Amount>), <Output item>, <Pressure (1 by default)>, <Time in ticks (200 by default)>)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Quickstart
 
-All new types are functions inside of the `global` object. They should be called inside of the `recipes` event like so: `global.more_recipe_types.<mod>.<type>(event, {args})`. For more info look at the section below.
+All new types are functions inside of the `global` object. They should be called inside of the `recipes` event like so: `global.more_recipe_types.<mod>.<type>(event, {args}, <id>)`. For more info look at the section below.
 
 ## Types
 
@@ -11,13 +11,13 @@ All new types are functions inside of the `global` object. They should be called
 #### Infusion
 
 ```js
-global.more_recipe_types.aoa3.infusion(event, <Main input item>, [<Other input items>], <Output item>)
+global.more_recipe_types.aoa3.infusion(event, <Main input item>, [<Other input items>], <Output item>, <id>)
 ```
 
 #### Upgrade Kit
 
 ```js
-global.more_recipe_types.aoa3.upgrade_kit(event, <Input item>, <Upgrade item>, <Output item>)
+global.more_recipe_types.aoa3.upgrade_kit(event, <Input item>, <Upgrade item>, <Output item>, <id>)
 ```
 
 ### Applied Energistics 2
@@ -25,13 +25,13 @@ global.more_recipe_types.aoa3.upgrade_kit(event, <Input item>, <Upgrade item>, <
 #### Grinder
 
 ```js
-global.more_recipe_types.appliedenergistics2.grinder(event, <Input item>, [<Output items>], <Turns (4 by default)>)
+global.more_recipe_types.appliedenergistics2.grinder(event, <Input item>, [<Output items>], <Turns (4 by default)>, <id>)
 ```
 
 #### Inscriber
 
 ```js
-global.more_recipe_types.appliedenergistics2.inscriber(event, [<Top input item>, <Middle input item>, <Bottom input item> (all air by default)], <Output item>, <Keep top and bottom (false by default)>)
+global.more_recipe_types.appliedenergistics2.inscriber(event, [<Top input item>, <Middle input item>, <Bottom input item> (all air by default)], <Output item>, <Keep top and bottom (false by default)>, <id>)
 ```
 
 ### Ars Nouveau
@@ -39,19 +39,19 @@ global.more_recipe_types.appliedenergistics2.inscriber(event, [<Top input item>,
 #### Enchanting Apparatus
 
 ```js
-global.more_recipe_types.ars_nouveau.enchanting_apparatus(event, <Middle input item>, [<Side input items>], <Output item>)
+global.more_recipe_types.ars_nouveau.enchanting_apparatus(event, <Middle input item>, [<Side input items>], <Output item>, <id>)
 ```
 
 #### Crush (Glyph)
 
 ```js
-global.more_recipe_types.ars_nouveau.crush(event, <Input item>, [Ingredient.of(<Output item>).withChance(<Chance>), ...])
+global.more_recipe_types.ars_nouveau.crush(event, <Input item>, [Ingredient.of(<Output item>).withChance(<Chance>), ...], <id>)
 ```
 
 #### Glyph Recipe (Glyph Press)
 
 ```js
-global.more_recipe_types.ars_nouveau.glyph_recipe(event, <Input item>, <Output item>, <Tier (1-3, 1 by default)>)
+global.more_recipe_types.ars_nouveau.glyph_recipe(event, <Input item>, <Output item>, <Tier (1-3, 1 by default)>, <id>)
 ```
 
 ### Astral Sorcery
@@ -59,25 +59,25 @@ global.more_recipe_types.ars_nouveau.glyph_recipe(event, <Input item>, <Output i
 #### Block Transmutation (Starlight Transmutation)
 
 ```js
-global.more_recipe_types.astralsorcery.block_transmutation(event, [<Input block (can use multiple)>], <Output block>, <Starlight>)
+global.more_recipe_types.astralsorcery.block_transmutation(event, [<Input block (can use multiple)>], <Output block>, <Starlight>, <id>)
 ```
 
 #### Infuser (Starlight Infusion)
 
 ```js
-global.more_recipe_types.astralsorcery.infuser(event, <Input item>, <Output item>, <Duration (100 by default)>, <Consumption chance (float, 0.1 by default)>, [>Consume multiple fluids (False by default)>, <Accept chalice input (True by default)>, <Copy NBT to output (False by default)>](Array can contain any number of booleans), <Input fluid id name ("astralsorcery:liquid_starlight" by default)>)
+global.more_recipe_types.astralsorcery.infuser(event, <Input item>, <Output item>, <Duration (100 by default)>, <Consumption chance (float, 0.1 by default)>, [>Consume multiple fluids (False by default)>, <Accept chalice input (True by default)>, <Copy NBT to output (False by default)>](Array can contain any number of booleans), <Input fluid id name ("astralsorcery:liquid_starlight" by default)>, <id>)
 ```
 
 #### Lightwell
 
 ```js
-global.more_recipe_types.astralsorcery.lightwell(event, <Input item>, <Output fluid id name>, <Production multiplier (float, 1 by default)>, <Shatter multiplier (float, lower = faster shatter, 10 by default)>, <color (white color by default)>)
+global.more_recipe_types.astralsorcery.lightwell(event, <Input item>, <Output fluid id name>, <Production multiplier (float, 1 by default)>, <Shatter multiplier (float, lower = faster shatter, 10 by default)>, <color (white color by default)>, <id>)
 ```
 
 #### Liquid Interaction
 
 ```js
-global.more_recipe_types.astralsorcery.liquid_interaction(event, [Fluid.of(<Input fluid 1>, <Amount>), <Chance consume fluid 1 (float, 100% by default)>], [Fluid.of(<Input fluid 2>, <Amount>), <Chance consume fluid 2 (float, 100% by default)>], <Output item>, <weight (1 by default)>)
+global.more_recipe_types.astralsorcery.liquid_interaction(event, [Fluid.of(<Input fluid 1>, <Amount>), <Chance consume fluid 1 (float, 100% by default)>], [Fluid.of(<Input fluid 2>, <Amount>), <Chance consume fluid 2 (float, 100% by default)>], <Output item>, <weight (1 by default)>, <id>)
 ```  
 
 ### Atum
@@ -85,19 +85,19 @@ global.more_recipe_types.astralsorcery.liquid_interaction(event, [Fluid.of(<Inpu
 #### Kiln
 
 ```js
-global.more_recipe_types.atum.kiln(event, <Input item>, <Output item>, <Experience (float, 0.1 by default)>)
+global.more_recipe_types.atum.kiln(event, <Input item>, <Output item>, <Experience (float, 0.1 by default)>, <id>)
 ```
 
 #### Quern
 
 ```js
-global.more_recipe_types.atum.quern(event, <Input item>, <Output item>, <Rotations (1 by default)>)
+global.more_recipe_types.atum.quern(event, <Input item>, <Output item>, <Rotations (1 by default)>, <id>)
 ```
 
 #### Spinning Wheel
 
 ```js
-global.more_recipe_types.atum.spinning_wheel(event, <Input item>, <Output item>, <Rotations (1 by default)>)
+global.more_recipe_types.atum.spinning_wheel(event, <Input item>, <Output item>, <Rotations (1 by default)>, <id>)
 ```
 
 ### Better End Forge
@@ -105,19 +105,19 @@ global.more_recipe_types.atum.spinning_wheel(event, <Input item>, <Output item>,
 #### Alloying
 
 ```js
-global.more_recipe_types.betterendforge.alloying(event, [<Input items>], <Output item>, <Experience (float, 1 by default)>, <Time in ticks (200 by default)>)
+global.more_recipe_types.betterendforge.alloying(event, [<Input items>], <Output item>, <Experience (float, 1 by default)>, <Time in ticks (200 by default)>, <id>)
 ```
 
 #### Anvil Smithing
 
 ```js
-global.more_recipe_types.betterendforge.anvil_smithing(event, <Input item>, <Output item>, <Tool level (0 by default = wood/gold)>, <Anvil level (1 by default)>, <Damage to tool (1 by default)>)
+global.more_recipe_types.betterendforge.anvil_smithing(event, <Input item>, <Output item>, <Tool level (0 by default = wood/gold)>, <Anvil level (1 by default)>, <Damage to tool (1 by default)>, <id>)
 ```
 
 #### Infusion
 
 ```js
-global.more_recipe_types.betterendforge.infusion(event, <Middle Input item>, [<Catalyst Input items (clockwise from top middle)>], <Output item>, <Time in seconds (100 by default)>)
+global.more_recipe_types.betterendforge.infusion(event, <Middle Input item>, [<Catalyst Input items (clockwise from top middle)>], <Output item>, <Time in seconds (100 by default)>, <id>)
 ```
 
 ### (Space) Boss Tools
@@ -125,13 +125,13 @@ global.more_recipe_types.betterendforge.infusion(event, <Middle Input item>, [<C
 #### Blasting
 
 ```js
-global.more_recipe_types.boss_tools.blasting(event, <Input item>, <Output item>, <Cook time (200 by default)>)
+global.more_recipe_types.boss_tools.blasting(event, <Input item>, <Output item>, <Cook time (200 by default)>, <id>)
 ```
 
 #### Compressing
 
 ```js
-global.more_recipe_types.boss_tools.compressing(event, <Input item>, <Output item>, <Cook time (200 by default)>)
+global.more_recipe_types.boss_tools.compressing(event, <Input item>, <Output item>, <Cook time (200 by default)>, <id>)
 ```
 
 ### Botania
@@ -139,25 +139,25 @@ global.more_recipe_types.boss_tools.compressing(event, <Input item>, <Output ite
 #### Brew (Botanical Brewery)
 
 ```js
-global.more_recipe_types.botania.brew(event, [<Input items>], <Output Brew id name (example: "botania:haste")>)
+global.more_recipe_types.botania.brew(event, [<Input items>], <Output Brew id name (example: "botania:haste")>, <id>)
 ```
 
 #### Elven Trade
 
 ```js
-global.more_recipe_types.botania.elven_trade(event, [<Input items>], [<Output items>])
+global.more_recipe_types.botania.elven_trade(event, [<Input items>], [<Output items>], <id>)
 ```
 
 #### Mana Infusion
 
 ```js
-global.more_recipe_types.botania.mana_infusion(event, <Output items>, <Output item>, <Mana (1000 by default)>, "Catalyst")
+global.more_recipe_types.botania.mana_infusion(event, <Output items>, <Output item>, <Mana (1000 by default)>, "Catalyst", <id>)
 ```
 
 #### Petal Aplothecary
 
 ```js
-global.more_recipe_types.botania.petal_apothecary(event, [<Input items>], <Output item>)
+global.more_recipe_types.botania.petal_apothecary(event, [<Input items>], <Output item>, <id>)
 ```
 
 #### Pure Daisy
@@ -169,13 +169,13 @@ global.more_recipe_types.botania.pure_daisy(event, <Input block>, <Output block>
 #### Runic Altar
 
 ```js
-global.more_recipe_types.botania.runic_altar(event, [<Input items>], <Output item>, <Mana (5000 by default)>)
+global.more_recipe_types.botania.runic_altar(event, [<Input items>], <Output item>, <Mana (5000 by default)>, <id>)
 ```
 
 #### Terra Plate (Terrestrial Agglomeration)
 
 ```js
-global.more_recipe_types.botania.terra_plate(event, [<Input items>], <Output item>, <Mana (100000 by default)>)
+global.more_recipe_types.botania.terra_plate(event, [<Input items>], <Output item>, <Mana (100000 by default)>, <id>)
 ```
 
 ### Botany Pots
@@ -183,19 +183,19 @@ global.more_recipe_types.botania.terra_plate(event, [<Input items>], <Output ite
 #### Crop
 
 ```js
-global.more_recipe_types.botanypots.crop(event, <Input seed>, [<Soil categories>], [[<Output item>, <Chance (float, 1 by default)>, <Min rolls (1 by default)>, <Max Rolls (1 by default)>], ...], <Growth ticks (1200 by default)>, <Display block (Input seed by default. Change if seed is item!)>)
+global.more_recipe_types.botanypots.crop(event, <Input seed>, [<Soil categories>], [[<Output item>, <Chance (float, 1 by default)>, <Min rolls (1 by default)>, <Max Rolls (1 by default)>], ...], <Growth ticks (1200 by default)>, <Display block (Input seed by default. Change if seed is item!)>, <id>)
 ```
 
 #### Fertilizer
 
 ```js
-global.more_recipe_types.botanypots.fertilizer(event, <Input Fertilizer>, <Min ticks (100 by default)>, <Max ticks (Min ticks + 100 by default)>)
+global.more_recipe_types.botanypots.fertilizer(event, <Input Fertilizer>, <Min ticks (100 by default)>, <Max ticks (Min ticks + 100 by default)>, <id>)
 ```
 
 #### Soil
 
 ```js
-global.more_recipe_types.botanypots.soil(event, <Input soil>, [<Soil categories>], <Growth modifier (float between -1 and 1, 0 by default)>, <Display block (Input soil by default. Change if soil is item!)>)
+global.more_recipe_types.botanypots.soil(event, <Input soil>, [<Soil categories>], <Growth modifier (float between -1 and 1, 0 by default)>, <Display block (Input soil by default. Change if soil is item!)>, <id>)
 ```
 
 ### Draconic Evolution
@@ -203,7 +203,7 @@ global.more_recipe_types.botanypots.soil(event, <Input soil>, [<Soil categories>
 #### Fusion Crafting
 
 ```js
-global.more_recipe_types.draconicevolution.fusion_crafting(event, <Main input item>, [<side Input items>], <Output item>, <Tier (of DRACONIUM = default, WYVERN, DRACONIC, CHAOTIC)>, <Energy (100000 by default)>)
+global.more_recipe_types.draconicevolution.fusion_crafting(event, <Main input item>, [<side Input items>], <Output item>, <Tier (of DRACONIUM = default, WYVERN, DRACONIC, CHAOTIC)>, <Energy (100000 by default)>, <id>)
 ```
 
 ### DivineRPG
@@ -211,13 +211,13 @@ global.more_recipe_types.draconicevolution.fusion_crafting(event, <Main input it
 #### Infusion Table
 
 ```js
-global.more_recipe_types.divinerpg.infusion_table(event, <Input item>, <Input template>, <Output item>)
+global.more_recipe_types.divinerpg.infusion_table(event, <Input item>, <Input template>, <Output item>, <id>)
 ```
 
 #### Fusion Crafting
 
 ```js
-global.more_recipe_types.draconicevolution.fusion_crafting(event, <Main input item>, [<side Input items>], <Output item>, <Tier (of DRACONIUM = default, WYVERN, DRACONIC, CHAOTIC)>, <Energy (100000 by default)>)
+global.more_recipe_types.draconicevolution.fusion_crafting(event, <Main input item>, [<side Input items>], <Output item>, <Tier (of DRACONIUM = default, WYVERN, DRACONIC, CHAOTIC)>, <Energy (100000 by default)>, <id>)
 ```
 
 ### Elemental Craft
@@ -225,49 +225,49 @@ global.more_recipe_types.draconicevolution.fusion_crafting(event, <Main input it
 #### Binding (Element Binding)
 
 ```js
-global.more_recipe_types.elementalcraft.binding(event, [<Input items>], <Output item>, <Element Type>, <Element Amount (1000 by default)>)
+global.more_recipe_types.elementalcraft.binding(event, [<Input items>], <Output item>, <Element Type>, <Element Amount (1000 by default)>, <id>)
 ```
 
 #### Crystallization (Gem Crystallization)
 
 ```js
-global.more_recipe_types.elementalcraft.crystallization(event, [<Gem input item>, <Crystal input item>, <Shard input item>], [[<Output item>, <Weight (1 by default)>, <Quality (null by default)>], ...], <Element Type>, <Element Amount (1000 by default)>)
+global.more_recipe_types.elementalcraft.crystallization(event, [<Gem input item>, <Crystal input item>, <Shard input item>], [[<Output item>, <Weight (1 by default)>, <Quality (null by default)>], ...], <Element Type>, <Element Amount (1000 by default)>, <id>)
 ```
 
 #### Grinding
 
 ```js
-global.more_recipe_types.elementalcraft.grinding(event, <Input item>, <Output item>, <Element Amount (1000 by default)>)
+global.more_recipe_types.elementalcraft.grinding(event, <Input item>, <Output item>, <Element Amount (1000 by default)>, <id>)
 ```
 
 #### Tool Infusion (Element Infusion)
 
 ```js
-global.more_recipe_types.elementalcraft.tool_infusion(event, <Input item>, <Tool infusion type (e.g.: "elementalcraft:fire_aspect")>, <Element Amount (1000 by default)>)
+global.more_recipe_types.elementalcraft.tool_infusion(event, <Input item>, <Tool infusion type (e.g.: "elementalcraft:fire_aspect")>, <Element Amount (1000 by default)>, <id>)
 ```
 
 #### Infusion (Element Infusion)
 
 ```js
-global.more_recipe_types.elementalcraft.infusion(event, <Input item>, <Output Item>, <Element Type>, <Element Amount (1000 by default)>)
+global.more_recipe_types.elementalcraft.infusion(event, <Input item>, <Output Item>, <Element Type>, <Element Amount (1000 by default)>, <id>)
 ```
 
 #### Inscription (Rune Inscription)
 
 ```js
-global.more_recipe_types.elementalcraft.inscription(event, [<Slate input item>, <3 other input items>], [<Output item>, <nbt>], <Element Type>, <Element Amount (1000 by default)>)
+global.more_recipe_types.elementalcraft.inscription(event, [<Slate input item>, <3 other input items>], [<Output item>, <nbt>], <Element Type>, <Element Amount (1000 by default)>, <id>)
 ```
 
 #### Pure Infusion
 
 ```js
-global.more_recipe_types.elementalcraft.pureinfusion(event, [<middle input item>, <Water input item>, <Fire input item>, <Earth input item>, <Air input item>], <Output Item>, <Element Amount (1000 by default)>)
+global.more_recipe_types.elementalcraft.pureinfusion(event, [<middle input item>, <Water input item>, <Fire input item>, <Earth input item>, <Air input item>], <Output Item>, <Element Amount (1000 by default)>, <id>)
 ```
 
 #### Spell Craft
 
 ```js
-global.more_recipe_types.elementalcraft.spell_craft(event, [<Gem input item>, <Crystal input item>], [<Output item>, <nbt>])
+global.more_recipe_types.elementalcraft.spell_craft(event, [<Gem input item>, <Crystal input item>], [<Output item>, <nbt>], <id>)
 ```
 
 ### Evil Craft
@@ -275,13 +275,13 @@ global.more_recipe_types.elementalcraft.spell_craft(event, [<Gem input item>, <C
 #### Blood Infuser
 
 ```js
-global.more_recipe_types.evilcraft.blood_infuser(event, <Input item>, Fluid.of(<Input fluid>, <Amount>), <Output item>, <Tier (0-3, 0 by default)>, <time in ticks (200 by default)>, <Experience (float, 0.1 by default)>)
+global.more_recipe_types.evilcraft.blood_infuser(event, <Input item>, Fluid.of(<Input fluid>, <Amount>), <Output item>, <Tier (0-3, 0 by default)>, <time in ticks (200 by default)>, <Experience (float, 0.1 by default)>, <id>)
 ```
 
 #### Environmental Accumulator / Sanguinary Environmental Accumulator
 
 ```js
-global.more_recipe_types.evilcraft.environmental_accumulator(event, <Input item>, <Input action (e.g. LIGHTNING)>, <Output item>, <Output weather (ANY, CLEAR, RAIN, LIGHTNING)>, <time in ticks (100 by default)>, <Cooldown time in ticks (0 by default)>)
+global.more_recipe_types.evilcraft.environmental_accumulator(event, <Input item>, <Input action (e.g. LIGHTNING)>, <Output item>, <Output weather (ANY, CLEAR, RAIN, LIGHTNING)>, <time in ticks (100 by default)>, <Cooldown time in ticks (0 by default)>, <id>)
 ```
 
 ### FTB Industrial Contraptions
@@ -289,13 +289,13 @@ global.more_recipe_types.evilcraft.environmental_accumulator(event, <Input item>
 #### Antimatter Boost
 
 ```js
-global.more_recipe_types.ftbic.antimatter_boost(event, <Input item>, <Boost (1000 by default)>)
+global.more_recipe_types.ftbic.antimatter_boost(event, <Input item>, <Boost (1000 by default)>, <id>)
 ```
 
 #### Basic Generator Fuel
 
 ```js
-global.more_recipe_types.ftbic.basic_generator_fuel(event, <Input item>, <Burn ticks (1 tick = 10 zaps, 200 by default)>)
+global.more_recipe_types.ftbic.basic_generator_fuel(event, <Input item>, <Burn ticks (1 tick = 10 zaps, 200 by default)>, <id>)
 ```
 
 #### Other Machines
@@ -310,12 +310,12 @@ Supported types:
 - seperating
 
 ```js
-global.more_recipe_types.ftbic.<type>(event, [<Input items>], [<Output Items>])
+global.more_recipe_types.ftbic.<type>(event, [<Input items>], [<Output Items>], <id>)
 ```
 
 Some notes:
 
-- To use nbt in input items use Item.of("Input item", "nbt")
+- To use nbt in input items use Item.of(`<Input item>`, `<nbt>`)
 - To use chance in output items use Item.of("Input item").withChance("Chance")
 
 ### Industrial Foregoing
@@ -323,25 +323,25 @@ Some notes:
 #### Dissolution Chamber
 
 ```js
-global.more_recipe_types.industrialforegoing.dissolution_chamber(event, [<Input items>], Fluid.of(<Input fluid>, <Amount>), <Output item>, <Output fluid (nothing by default)>, <Time in ticks (20 by default)>)
+global.more_recipe_types.industrialforegoing.dissolution_chamber(event, [<Input items>], Fluid.of(<Input fluid>, <Amount>), <Output item>, <Output fluid (nothing by default)>, <Time in ticks (20 by default)>, <id>)
 ```
 
 #### Fluid Extractor
 
 ```js
-global.more_recipe_types.industrialforegoing.fluid_extractor(event, <Input block>, Fluid.of(<Output fluid>, <Amount>), <Block damage chance (float, 0% by default)>, <Result block ("minecraft:air" by default)>)
+global.more_recipe_types.industrialforegoing.fluid_extractor(event, <Input block>, Fluid.of(<Output fluid>, <Amount>), <Block damage chance (float, 0% by default)>, <Result block ("minecraft:air" by default)>, <id>)
 ```
 
 #### Laser Drill (Ore / Fluid)
 
 ```js
-global.more_recipe_types.industrialforegoing.laser_drill(event, <Output item / Fluid.of(<Output Fluid>, <Amount>)>, <Catalyst Item>, [[[[<List values (empty by default)>], <List Blacklist ? (else whitelist, false by default)>, <List type ("minecraft:worldgen/biome" by default)>], [<Min depth (0 by default)>, <Max depth (64 by default)>], <Weight (1 by default)>], ...], <Fluid recipe ? (false by default)>, <Entity (only if Fluid recipe, no entity by default)>)
+global.more_recipe_types.industrialforegoing.laser_drill(event, <Output item / Fluid.of(<Output Fluid>, <Amount>)>, <Catalyst Item>, [[[[<List values (empty by default)>], <List Blacklist ? (else whitelist, false by default)>, <List type ("minecraft:worldgen/biome" by default)>], [<Min depth (0 by default)>, <Max depth (64 by default)>], <Weight (1 by default)>], ...], <Fluid recipe ? (false by default)>, <Entity (only if Fluid recipe, no entity by default)>, <id>)
 ```
 
 #### Stonework Generate
 
 ```js
-global.more_recipe_types.industrialforegoing.stonework_generate(event, <Output Item>, [<Water requirement (1000 by default)>, <Water usage (0 by default)>], [<Lava requirement (1000 by default)>, <Lava usage (0 by default)>])
+global.more_recipe_types.industrialforegoing.stonework_generate(event, <Output Item>, [<Water requirement (1000 by default)>, <Water usage (0 by default)>], [<Lava requirement (1000 by default)>, <Lava usage (0 by default)>], <id>)
 ```
 
 ### Mystical Agriculture
@@ -349,19 +349,19 @@ global.more_recipe_types.industrialforegoing.stonework_generate(event, <Output I
 #### Infusion (Crafting)
 
 ```js
-global.more_recipe_types.mysticalagriculture.infusion(event, <Middle input item>, [<Side input items>], <Output item>)
+global.more_recipe_types.mysticalagriculture.infusion(event, <Middle input item>, [<Side input items>], <Output item>, <id>)
 ```
 
 #### (Seed) Reprocessing
 
 ```js
-global.more_recipe_types.mysticalagriculture.reprocessor(event, <Input item>, <Output item>)
+global.more_recipe_types.mysticalagriculture.reprocessor(event, <Input item>, <Output item>, <id>)
 ```
 
 #### Soul Extraction
 
 ```js
-global.more_recipe_types.mysticalagriculture.soul_extraction(event, <Input item>, <Soul type (e.g. "mysticalagriculture:skeleton")>, <Soul amount (1 by default)>)
+global.more_recipe_types.mysticalagriculture.soul_extraction(event, <Input item>, <Soul type (e.g. "mysticalagriculture:skeleton")>, <Soul amount (1 by default)>, <id>)
 ```
 
 ### PneumaticCraft: Repressurized
@@ -369,61 +369,61 @@ global.more_recipe_types.mysticalagriculture.soul_extraction(event, <Input item>
 #### Amadron (Amadron Tablet)
 
 ```js
-global.more_recipe_types.pneumaticcraft.amadron(event, [<Input item / Fluid.of(<Input fluid>, <Amount>)>, <Input is Fluid ? (false by default)>], [<Output item / Fluid.of(<Output fluid>, <Amount>)>, <Output is Fluid ? (false by default)>])
+global.more_recipe_types.pneumaticcraft.amadron(event, [<Input item / Fluid.of(<Input fluid>, <Amount>)>, <Input is Fluid ? (false by default)>], [<Output item / Fluid.of(<Output fluid>, <Amount>)>, <Output is Fluid ? (false by default)>], <id>)
 ```
 
 #### Assembly Laser (Assembly Controller)
 
 ```js
-global.more_recipe_types.pneumaticcraft.assembly_laser(event, <Input item>, <Output item>, <Type is Drill ? (false by default)>)
+global.more_recipe_types.pneumaticcraft.assembly_laser(event, <Input item>, <Output item>, <Type is Drill ? (false by default)>, <id>)
 ```
 
 #### Explosion Crafting
 
 ```js
-global.more_recipe_types.pneumaticcraft.explosion_crafting(event, <Input item>, [<Output items>], <Loss rate (0 - 100, 20 by default)>)
+global.more_recipe_types.pneumaticcraft.explosion_crafting(event, <Input item>, [<Output items>], <Loss rate (0 - 100, 20 by default)>, <id>)
 ```
 
 #### Heat Frame Cooling
 
 ```js
-global.more_recipe_types.pneumaticcraft.heat_frame_cooling(event, [<Input fluid>, <Amount>], <Output item>, <Max temperature (0°C by default)>, [<Bonus output multiplier per degree (0 by default)>, <Bonus output max multiplier (0 by default)>])
+global.more_recipe_types.pneumaticcraft.heat_frame_cooling(event, [<Input fluid>, <Amount>], <Output item>, <Max temperature (0°C by default)>, [<Bonus output multiplier per degree (0 by default)>, <Bonus output max multiplier (0 by default)>], <id>)
 ```
 
 #### (Block) Heat Properties
 
 ```js
-global.more_recipe_types.pneumaticcraft.heat_properties(event, <Input block>, [<Output block from Cooling>, <Output block from Heating>], <Block temperature (25°C by default)>, <Thermal Resictance (20 by default)>, <Heat Capacity (1000 by default)>)
+global.more_recipe_types.pneumaticcraft.heat_properties(event, <Input block>, [<Output block from Cooling>, <Output block from Heating>], <Block temperature (25°C by default)>, <Thermal Resictance (20 by default)>, <Heat Capacity (1000 by default)>, <id>)
 ```
 
 #### Fluid Mixer
 
 ```js
-global.more_recipe_types.pneumaticcraft.fluid_mixer(event, [<Input Fluid 1>, <Amount (1000 by default)>], <Input Fluid 2>, <Amount (1000 by default)>], Fluid.of(<Output Fluid>, <Amount>), <Output item>, <Pressure (1 by default)>, <Time in ticks (200 by default)>)
+global.more_recipe_types.pneumaticcraft.fluid_mixer(event, [<Input Fluid 1>, <Amount (1000 by default)>], <Input Fluid 2>, <Amount (1000 by default)>], Fluid.of(<Output Fluid>, <Amount>), <Output item>, <Pressure (1 by default)>, <Time in ticks (200 by default)>, <id>)
 ```
 
 #### Fuel Quality
 
 ```js
-global.more_recipe_types.pneumaticcraft.fuel_quality(event, <Input fluid>, <Air per bucket (100000 by default)>, <Burn rate (float, 1 by default)>)
+global.more_recipe_types.pneumaticcraft.fuel_quality(event, <Input fluid>, <Air per bucket (100000 by default)>, <Burn rate (float, 1 by default)>, <id>)
 ```
 
 #### Pressure Chamber
 
 ```js
-global.more_recipe_types.pneumaticcraft.pressure_chamber(event, [<Input items>], [<Output items>], <Pressure (1 by default)>)
+global.more_recipe_types.pneumaticcraft.pressure_chamber(event, [<Input items>], [<Output items>], <Pressure (1 by default)>, <id>)
 ```
 
 #### Refinery (Refinery Controller)
 
 ```js
-global.more_recipe_types.pneumaticcraft.refinery(event, [<Input fluid>, <Amount (1000 by default)>], [Fluid.of(<Output Fluid>, <Amount>), ... (atleast two fluids)], [<Min temperature>, <Max temperature>])
+global.more_recipe_types.pneumaticcraft.refinery(event, [<Input fluid>, <Amount (1000 by default)>], [Fluid.of(<Output Fluid>, <Amount>), ... (atleast two fluids)], [<Min temperature>, <Max temperature>], <id>)
 ```
 
 #### Thermo Plant (Thermopneumatic Processing Plant)
 
 ```js
-global.more_recipe_types.pneumaticcraft.thermo_plant(event, <Input item>, [<Input fluid>, <Amount>], <Output item>, Fluid.of(<Ouput fluid>, <Amount>), [<Min temperature>, <Max temperature>], <Pressure>, <Speed (float, 1 by default)>, <is Exothermic ? (false by default)>)   
+global.more_recipe_types.pneumaticcraft.thermo_plant(event, <Input item>, [<Input fluid>, <Amount>], <Output item>, Fluid.of(<Ouput fluid>, <Amount>), [<Min temperature>, <Max temperature>], <Pressure>, <Speed (float, 1 by default)>, <is Exothermic ? (false by default)>, <id>)   
 ```
 
 ### Powah
@@ -431,7 +431,7 @@ global.more_recipe_types.pneumaticcraft.thermo_plant(event, <Input item>, [<Inpu
 #### Energizing
 
 ```js
-global.more_recipe_types.powah.energizing(event, [<Input items>], <Output item>, <Energy (100 by default)>)
+global.more_recipe_types.powah.energizing(event, [<Input items>], <Output item>, <Energy (100 by default)>, <id>)
 ```
 
 ### Psi
@@ -439,7 +439,7 @@ global.more_recipe_types.powah.energizing(event, [<Input items>], <Output item>,
 #### Trick Crafting (Spell Infusion)
 
 ```js
-global.more_recipe_types.psi.trick_crafting(event, <Input item>, <Output item>, <Cad assemby>, <Trick>, <Dimension (Isn't listed in JEI)>)
+global.more_recipe_types.psi.trick_crafting(event, <Input item>, <Output item>, <Cad assemby>, <Trick>, <Dimension (Isn't listed in JEI)>, <id>)
 ```
 
 ### Silent Gear
@@ -447,13 +447,13 @@ global.more_recipe_types.psi.trick_crafting(event, <Input item>, <Output item>, 
 #### Compounding
 
 ```js
-global.more_recipe_types.silentgear.compounding(event, [<Input items>], <Output item>, <Gem Compounding ? (else Metal, false by default)>)
+global.more_recipe_types.silentgear.compounding(event, [<Input items>], <Output item>, <Gem Compounding ? (else Metal, false by default)>, <id>)
 ```
 
 #### Salvaging
 
 ```js
-global.more_recipe_types.silentgear.salvaging(event, <Input item>, [<Output items>])
+global.more_recipe_types.silentgear.salvaging(event, <Input item>, [<Output items>], <id>)
 ```
 
 ### Silent's Mechanism's
@@ -461,49 +461,49 @@ global.more_recipe_types.silentgear.salvaging(event, <Input item>, [<Output item
 #### Alloy Smelting
 
 ```js
-global.more_recipe_types.silents_mechanisms.alloy_smelting(event, [[[<Input item>, ...], <Amount>], ...], <Output item>, <Time in ticks (200 by default)>)
+global.more_recipe_types.silents_mechanisms.alloy_smelting(event, [[[<Input item>, ...], <Amount>], ...], <Output item>, <Time in ticks (200 by default)>, <id>)
 ```
 
 #### Compressing
 
 ```js
-global.more_recipe_types.silents_mechanisms.compressing(event, [[<Input item>, ...], <Amount>], <Output item>, <Time in ticks (200 by default)>)
+global.more_recipe_types.silents_mechanisms.compressing(event, [[<Input item>, ...], <Amount>], <Output item>, <Time in ticks (200 by default)>, <id>)
 ```
 
 #### Crushing
 
 ```js
-global.more_recipe_types.silents_mechanisms.crushing(event, <Input item>, [<Output items>], <Time in ticks (200 by default)>)
+global.more_recipe_types.silents_mechanisms.crushing(event, <Input item>, [<Output items>], <Time in ticks (200 by default)>, <id>)
 ```
 
 #### Drying
 
 ```js
-global.more_recipe_types.silents_mechanisms.drying(event, <Input item>, <Output item>, <Time in ticks (200 by default)>)
+global.more_recipe_types.silents_mechanisms.drying(event, <Input item>, <Output item>, <Time in ticks (200 by default)>, <id>)
 ```
 
 #### Infusing
 
 ```js
-global.more_recipe_types.silents_mechanisms.infusing(event, <Input item>, [<Input fluid>, <Amount (1000 by default)>], <Output item>, <Time in ticks (200 by default)>)
+global.more_recipe_types.silents_mechanisms.infusing(event, <Input item>, [<Input fluid>, <Amount (1000 by default)>], <Output item>, <Time in ticks (200 by default)>, <id>)
 ```
 
 #### Mixing
 
 ```js
-global.more_recipe_types.silents_mechanisms.mixing(event, [[<Input fluid>, <Amount (1000 by default)>], ...], Fluid.of(<Output fluid>, <Amount>), <Time in ticks (200 by default)>)
+global.more_recipe_types.silents_mechanisms.mixing(event, [[<Input fluid>, <Amount (1000 by default)>], ...], Fluid.of(<Output fluid>, <Amount>), <Time in ticks (200 by default)>, <id>)
 ```
 
 #### Refining
 
 ```js
-global.more_recipe_types.silents_mechanisms.refining(event, [<Input fluid>, <Amount (1000 by default)>], [Fluid.of(<Output fluid>, <Amount>), ...], <Time in ticks (200 by default)>)
+global.more_recipe_types.silents_mechanisms.refining(event, [<Input fluid>, <Amount (1000 by default)>], [Fluid.of(<Output fluid>, <Amount>), ...], <Time in ticks (200 by default)>, <id>)
 ```
 
 #### Solidifying
 
 ```js
-global.more_recipe_types.silents_mechanisms.solidifying(event, [<Input fluid>, <Amount (1000 by default)>], <Output item>, <Time in ticks (200 by default)>)
+global.more_recipe_types.silents_mechanisms.solidifying(event, [<Input fluid>, <Amount (1000 by default)>], <Output item>, <Time in ticks (200 by default)>, <id>)
 ```
 
 ### Tinker's Construct
@@ -511,47 +511,47 @@ global.more_recipe_types.silents_mechanisms.solidifying(event, [<Input fluid>, <
 #### Alloy (Alloying)
 
 ```js
-global.more_recipe_types.tconstruct.alloy(event, [[<Input fluid>, <Amount (1000 by default)>], ...], Fluid.of(<Output fluid>, <Amount>), <Temperature (100 by default)>)
+global.more_recipe_types.tconstruct.alloy(event, [[<Input fluid>, <Amount (1000 by default)>], ...], Fluid.of(<Output fluid>, <Amount>), <Temperature (100 by default)>, <id>)
 ```
 
 #### Casting (Table / Basin)
 
 ```js
-global.more_recipe_types.tconstruct.casting(event, [<Input fluid>, <Amount (1000 by default)>], <Input Cast>, <Output item>, <Basin ? (else table, false by default)>, <Cast consumed ? (false by default)>, <Time in ticks (60 by default)>)
+global.more_recipe_types.tconstruct.casting(event, [<Input fluid>, <Amount (1000 by default)>], <Input Cast>, <Output item>, <Basin ? (else table, false by default)>, <Cast consumed ? (false by default)>, <Time in ticks (60 by default)>, <id>)
 ```
 
 #### Entity Melting
 
 ```js
-global.more_recipe_types.tconstruct.entity_melting(event, <Entity>, Fluid.of(<Output fluid>, <Amount>), <Damage (1 by default)>)
+global.more_recipe_types.tconstruct.entity_melting(event, <Entity>, Fluid.of(<Output fluid>, <Amount>), <Damage (1 by default)>, <id>)
 ```
 
 #### Melting
 
 ```js
-global.more_recipe_types.tconstruct.melting(event, <Input item>, Fluid.of(<Output fluid>, <Amount>), <Temperature (100 by default)>, <Time in ticks (300 by default)>)
+global.more_recipe_types.tconstruct.melting(event, <Input item>, Fluid.of(<Output fluid>, <Amount>), <Temperature (100 by default)>, <Time in ticks (300 by default)>, <id>)
 ```
 
 #### Molding (Table)
 
 ```js
-global.more_recipe_types.tconstruct.molding_table(event, <Input Cast>, <Input item>, <Output cast>)
+global.more_recipe_types.tconstruct.molding_table(event, <Input Cast>, <Input item>, <Output cast>, <id>)
 ```
 
 #### Part Builder
 
 ```js
-global.more_recipe_types.tconstruct.part_builder(event, <Input pattern>, <Output Part>, <Cost (1 by default)>)
+global.more_recipe_types.tconstruct.part_builder(event, <Input pattern>, <Output Part>, <Cost (1 by default)>, <id>)
 ```
 
 #### Severing
 
 ```js
-global.more_recipe_types.tconstruct.severing(event, <Entity>, <Output item>)
+global.more_recipe_types.tconstruct.severing(event, <Entity>, <Output item>, <id>)
 ```
 
 #### Casting Table with Parts (like Part Builder)
 
 ```js
-global.more_recipe_types.tconstruct.table_casting_material(event, <Input cast>, <Output Part>, <Cost (1 by default)>)
+global.more_recipe_types.tconstruct.table_casting_material(event, <Input cast>, <Output Part>, <Cost (1 by default)>, <id>)
 ```

--- a/README.md
+++ b/README.md
@@ -164,6 +164,14 @@ global.more_recipe_types.botanypots.fertilizer(event, <Input Fertilizer>, <Min t
 global.more_recipe_types.botanypots.soil(event, <Input soil>, [<Soil categories>], <Growth modifier (float between -1 and 1, 0 by default)>, <Display block (Input soil by default. Change if soil is item!)>)
 ```
 
+### Draconic Evolution
+
+#### Fusion Crafting
+
+```js
+global.more_recipe_types.draconicevolution.fusion_crafting(event, <Main input item>, [<side Input items>], <Output item>, <Tier (of DRACONIUM = default, WYVERN, DRACONIC, CHAOTIC)>, <Energy (100000 by default)>)
+```
+
 ### Elemental Craft
 
 #### Binding (Element Binding)

--- a/README.md
+++ b/README.md
@@ -296,6 +296,26 @@ global.more_recipe_types.industrialforegoing.laser_drill(event, <Output item / F
 global.more_recipe_types.industrialforegoing.stonework_generate(event, <Output Item>, [<Water requirement (1000 by default)>, <Water usage (0 by default)>], [<Lava requirement (1000 by default)>, <Lava usage (0 by default)>])
 ```
 
+### Mystical Agriculture
+
+#### Infusion (Crafting)
+
+```js
+global.more_recipe_types.mysticalagriculture.infusion(event, <Middle input item>, [<Side input items>], <Output item>)
+```
+
+#### (Seed) Reprocessing
+
+```js
+global.more_recipe_types.mysticalagriculture.reprocessor(event, <Input item>, <Output item>)
+```
+
+#### Soul Extraction
+
+```js
+global.more_recipe_types.mysticalagriculture.soul_extraction(event, <Input item>, <Soul type (e.g. "mysticalagriculture:skeleton")>, <Soul amount (1 by default)>)
+```
+
 ### PneumaticCraft: Repressurized
 
 #### Amadron (Amadron Tablet)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,26 @@ global.more_recipe_types.astralsorcery.lightwell(event, <Input item>, <Output fl
 global.more_recipe_types.astralsorcery.liquid_interaction(event, [Fluid.of(<Input fluid 1>, <Amount>), <Chance consume fluid 1 (float, 100% by default)>], [Fluid.of(<Input fluid 2>, <Amount>), <Chance consume fluid 2 (float, 100% by default)>], <Output item>, <weight (1 by default)>)
 ```  
 
+### Atum
+
+#### Kiln
+
+```js
+global.more_recipe_types.atum.kiln(event, <Input item>, <Output item>, <Experience (float, 0.1 by default)>)
+```
+
+#### Quern
+
+```js
+global.more_recipe_types.atum.quern(event, <Input item>, <Output item>, <Rotations (1 by default)>)
+```
+
+#### Spinning Wheel
+
+```js
+global.more_recipe_types.atum.spinning_wheel(event, <Input item>, <Output item>, <Rotations (1 by default)>)
+```
+
 ### (Space) Boss Tools
 
 #### Blasting

--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ global.more_recipe_types.ftbic.<type>(event, [<Input items>], [<Output Items>])
 
 Some notes:
 
-- To use nbt in input items use Item.of("<Input item>", "<nbt>")
-- To use chance in output items use Item.of("<Input item>").withChance("<Chance>")
+- To use nbt in input items use Item.of("Input item", "nbt")
+- To use chance in output items use Item.of("Input item").withChance("Chance")
 
 ### Industrial Foregoing
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ All new types are functions inside of the `global` object. They should be called
 
 ## Types
 
+### Advent of Ascension 3
+
+#### Infusion
+
+```js
+global.more_recipe_types.aoa3.infusion(event, <Main input item>, [<Other input items>], <Output item>)
+```
+
+#### Upgrade Kit
+
+```js
+global.more_recipe_types.aoa3.upgrade_kit(event, <Input item>, <Upgrade item>, <Output item>)
+```
+
 ### Applied Energistics 2
 
 #### Grinder

--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ global.more_recipe_types.astralsorcery.lightwell(event, <Input item>, <Output fl
 global.more_recipe_types.astralsorcery.liquid_interaction(event, [Fluid.of(<Input fluid 1>, <Amount>), <Chance consume fluid 1 (float, 100% by default)>], [Fluid.of(<Input fluid 2>, <Amount>), <Chance consume fluid 2 (float, 100% by default)>], <Output item>, <weight (1 by default)>)
 ```  
 
+### (Space) Boss Tools
+
+#### Blasting
+
+```js
+global.more_recipe_types.boss_tools.blasting(event, <Input item>, <Output item>, <Cook time (200 by default)>)
+```
+
+#### Compressing
+
+```js
+global.more_recipe_types.boss_tools.compressing(event, <Input item>, <Output item>, <Cook time (200 by default)>)
+```
+
 ### Botania
 
 #### Brew (Botanical Brewery)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,25 @@ global.more_recipe_types.appliedenergistics2.grinder(event, <Input item>, [<Outp
 global.more_recipe_types.appliedenergistics2.inscriber(event, [<Top input item>, <Middle input item>, <Bottom input item> (all air by default)], <Output item>, <Keep top and bottom (false by default)>)
 ```
 
+### Ars Nouveau
+
+#### Enchanting Apparatus
+
+```js
+global.more_recipe_types.ars_nouveau.enchanting_apparatus(event, <Middle input item>, [<Side input items>], <Output item>)
+```
+
+#### Crush (Glyph)
+
+```js
+global.more_recipe_types.ars_nouveau.crush(event, <Input item>, [Ingredient.of(<Output item>).withChance(<Chance>), ...])```
+
+#### Glyph Recipe (Glyph Press)
+
+```js
+global.more_recipe_types.ars_nouveau.glyph_recipe(event, <Input item>, <Output item>, <Tier (1-3, 1 by default)>)
+```
+
 ### Astral Sorcery
 
 #### Block Transmutation (Starlight Transmutation)

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -1145,6 +1145,25 @@ onEvent("loaded", e => {
 				event.custom(recipe)
 			}
 		},
+		
+		silentgear: {
+			compounding: (event, input, output, isGem) => {
+				event.custom({
+					type: isGem===true ? "silentgear:compounding/gem" : "silentgear:compounding/metal",
+					
+					ingredients: ingredientsConvert(arrConvert(input).slice(0, 4)),
+					result: Ingredient.of(output)
+				})
+			},
+			salvaging: (event, input, output) => {
+				event.custom({
+					type: "silentgear:salvaging",
+					
+					ingredient: Ingredient.of(input),
+					results: ingredientsConvert(arrConvert(output).slice(0, 9))
+				})
+			}
+		},
 
 		silents_mechanisms: {
 			alloy_smelting: (event, input, output, time) => {

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -595,6 +595,44 @@ onEvent("loaded", e => {
 			}
 		},
 
+		evilcraft: {
+			blood_infuser: (event, inputItem, inputFluid, output, tier, time, experience) => {
+				if (typeof experience!="number") experience = 0.1
+				if (typeof tier!="number") tier = 0
+				if (typeof time!="number") time = 200
+
+				event.custom({
+					type: "evilcraft:blood_infuser",
+					
+					item: Ingredient.of(inputItem),
+					fluid: fluidConvert(inputFluid).toJson(),
+					result: Ingredient.of(output),
+					
+					duration: time,
+					xp: experience,
+					tier: tier
+				})
+			},
+			environmental_accumulator: (event, input, inputAction, output, outputWeather, time, cooldownTime) => {
+				if (typeof time!="number") time = 100
+				if (typeof cooldownTime!="number") cooldownTime = 0
+
+				event.custom({
+					type: "evilcraft:environmental_accumulator",
+					
+					item: Ingredient.of(input).id,
+					weather: inputAction,
+					result: {
+						item: Ingredient.of(output).id,
+						weather: outputWeather
+					},
+					
+					duration: time,
+					cooldownTime: cooldownTime
+				})
+			}
+		},
+		
 		ftbic: {
 			antimatter_boost: (event, input, boost) => {
 				if (typeof boost!="number") boost = 1000

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -51,7 +51,7 @@ function blockIngredientsConvert(i, withType) {
 	i.forEach(block => {ingredients.push(blockConvert(block, withType))})
 	return ingredients
 }
-function addFTBICRecipes(event, input, output, type) {
+function addFTBICRecipes(event, input, output, type, id) {
 	let ingredients = []
 	input.forEach(item => {
 		let ingredient = Ingredient.of(item)
@@ -69,7 +69,7 @@ function addFTBICRecipes(event, input, output, type) {
 
 		inputItems: ingredients,
 		outputItems: ingredientsConvert(arrConvert(output))
-	})
+	}).id(id)
 }
 function SMIngredientConvert(i) {
 	let values = []
@@ -86,28 +86,28 @@ let i
 onEvent("loaded", e => {
 	global.more_recipe_types = {
 		aoa3: {
-			infusion: (event, mainInput, input, output) => {
+			infusion: (event, mainInput, input, output, id) => {
 				event.custom({
 					type: "aoa3:infusion",
 
 					input: Ingredient.of(mainInput),
 					ingredients: ingredientsConvert(arrConvert(input).slice(0, 9)),
 					result: Ingredient.of(output)
-				})
+				}).id(id)
 			},
-			upgrade_kit: (event, input, upgradeKit, output) => {
+			upgrade_kit: (event, input, upgradeKit, output, id) => {
 				event.custom({
 					type: "aoa3:upgrade_kit",
 
 					input: Ingredient.of(input),
 					upgrade_kit: Ingredient.of(upgradeKit),
 					result: Ingredient.of(output)
-				})
+				}).id(id)
 			}
 		},
 
 		appliedenergistics2: {
-			grinder: (event, input, output, turns) => {
+			grinder: (event, input, output, turns, id) => {
 				output = ingredientsConvert(arrConvert(output).slice(0, 3))
 				if (typeof turns!="number") turns = 4
 
@@ -121,9 +121,9 @@ onEvent("loaded", e => {
 					},
 
 					turns: turns
-				})
+				}).id(id)
 			},
-			inscriber: (event, input, output, keep) => {
+			inscriber: (event, input, output, keep, id) => {
 				input = ingredientsConvert(arrConvert(input).slice(0, 3))
 				let input_names = ["top", "middle", "bottom"]
 				let ingredients = {}
@@ -139,12 +139,12 @@ onEvent("loaded", e => {
 
 					ingredients: ingredients,
 					result: Ingredient.of(output)
-				})
+				}).id(id)
 			}
 		},
 
 		ars_nouveau: {
-			enchanting_apparatus: (event, mainInput, sideInput, output) => {
+			enchanting_apparatus: (event, mainInput, sideInput, output, id) => {
 				let recipe = {
 					type: "ars_nouveau:enchanting_apparatus",
 
@@ -159,18 +159,18 @@ onEvent("loaded", e => {
 					}
 				}
 
-				event.custom(recipe)
+				event.custom(recipe).id(id)
 			},
-			crush: (event, input, output) => {
+			crush: (event, input, output, id) => {
 
 				event.custom({
 					type: "ars_nouveau:crush",
 					
 					input: Ingredient.of(input),
 					output: ingredientsConvert(arrConvert(output))
-				})
+				}).id(id)
 			},
-			glyph_recipe: (event, input, output, tier) => {
+			glyph_recipe: (event, input, output, tier, id) => {
 				if (typeof tier!="number" && typeof tier!="string") tier = 1
 				tier = ["ONE", "TWO", "THREE"][tier - 1]
 
@@ -180,12 +180,12 @@ onEvent("loaded", e => {
 					input: Ingredient.of(input).id,
 					output: Ingredient.of(output).id,
 					tier: tier===undefined ? "ONE" : tier
-				})
+				}).id(id)
 			}
 		},
 
 		astralsorcery: {
-			block_transmutation: (event, input, output, starlight) => {
+			block_transmutation: (event, input, output, starlight, id) => {
 				if (typeof starlight!="number") starlight = 200
 
 				event.custom({
@@ -195,9 +195,9 @@ onEvent("loaded", e => {
 					output: {block: output},
 
 					starlight: starlight
-				})
+				}).id(id)
 			},
-			infuser: (event, input, output, duration, consumptionChance, settings, inputFluid) => {
+			infuser: (event, input, output, duration, consumptionChance, settings, inputFluid, id) => {
 				if (typeof duration!="number") duration = 100
 				if (typeof consumptionChance!="number") consumptionChance = 0.1
 				if (!Array.isArray(settings)) settings = [false, true, false]
@@ -219,7 +219,7 @@ onEvent("loaded", e => {
 					copyNBTToOutputs: settings[2]
 				})
 			},
-			lightwell: (event, input, outputFluid, productionMultiplier, shatterMultiplier, color) => {
+			lightwell: (event, input, outputFluid, productionMultiplier, shatterMultiplier, color, id) => {
 				if (typeof productionMultiplier!="number") productionMultiplier = 1
 				if (typeof shatterMultiplier!="number") shatterMultiplier = 10
 				if (typeof color!="number") color = -2236929
@@ -233,9 +233,9 @@ onEvent("loaded", e => {
 					productionMultiplier: productionMultiplier,
 					shatterMultiplier: shatterMultiplier,
 					color: color
-				})
+				}).id(id)
 			},
-			liquid_interaction: (event, inputFluid1, inputFluid2, output, weight) => {
+			liquid_interaction: (event, inputFluid1, inputFluid2, output, weight, id) => {
 				inputFluid1 = arrConvert(inputFluid1)
 				inputFluid2 = arrConvert(inputFluid2)
 				let fluid1 = fluidConvert(inputFluid1[0])
@@ -263,12 +263,12 @@ onEvent("loaded", e => {
 					},
 
 					weight: weight
-				})
+				}).id(id)
 			}
 		},
 
 		atum: {
-			kiln: (event, input, output, experience) => {
+			kiln: (event, input, output, experience, id) => {
 				if (typeof experience!="number") experience = 0.1
 
 				event.custom({
@@ -278,9 +278,9 @@ onEvent("loaded", e => {
 					result: Ingredient.of(output),
 
 					experience: experience
-				})
+				}).id(id)
 			},
-			quern: (event, input, output, rotations) => {
+			quern: (event, input, output, rotations, id) => {
 				if (typeof rotations!="number") rotations = 1
 
 				event.custom({
@@ -290,9 +290,9 @@ onEvent("loaded", e => {
 					result: Ingredient.of(output),
 
 					rotations: rotations
-				})
+				}).id(id)
 			},
-			spinning_wheel: (event, input, output, rotations) => {
+			spinning_wheel: (event, input, output, rotations, id) => {
 				if (typeof rotations!="number") rotations = 1
 
 				event.custom({
@@ -302,12 +302,12 @@ onEvent("loaded", e => {
 					result: Ingredient.of(output),
 
 					rotations: rotations
-				})
+				}).id(id)
 			}
 		},
 
 		betterendforge: {
-			alloying: (event, input, output, experience, time) => {
+			alloying: (event, input, output, experience, time, id) => {
 				if (typeof experience!="number") experience = 1
 				if (typeof time!="number") time = 200
 
@@ -319,9 +319,9 @@ onEvent("loaded", e => {
 
 					experience: experience,
 					smelttime: time
-				})
+				}).id(id)
 			},
-			anvil_smithing: (event, input, output, toolLevel, anvilLevel, toolDamage) => {
+			anvil_smithing: (event, input, output, toolLevel, anvilLevel, toolDamage, id) => {
 				if (typeof toolLevel!="number") toolLevel = 0
 				if (typeof anvilLevel!="number") anvilLevel = 1
 				if (typeof toolDamage!="number") toolDamage = 1
@@ -335,9 +335,9 @@ onEvent("loaded", e => {
 					level: toolLevel,
 					anvilLevel: anvilLevel,
 					damage: toolDamage
-				})
+				}).id(id)
 			},
-			infusion: (event, middleInput, catalystInput, output, time) => {
+			infusion: (event, middleInput, catalystInput, output, time, id) => {
 				catalystInput = arrConvert(catalystInput).slice(0, 8)
 				let catalysts = []
 				for (i = 0; i < catalystInput.length; i++) {
@@ -355,12 +355,12 @@ onEvent("loaded", e => {
 					catalysts: catalysts,
 					
 					time: time
-				})
+				}).id(id)
 			}
 		},
 		
 		boss_tools: {
-			blasting: (event, input, output, cookTime) => {
+			blasting: (event, input, output, cookTime, id) => {
 				if (typeof cookTime!="number") cookTime = 200
 
 				event.custom({
@@ -370,9 +370,9 @@ onEvent("loaded", e => {
 					output: Ingredient.of(output),
 
 					cookTime: cookTime
-				})
+				}).id(id)
 			},
-			compressing: (event, input, output, cookTime) => {
+			compressing: (event, input, output, cookTime, id) => {
 				if (typeof cookTime!="number") cookTime = 200
 
 				event.custom({
@@ -382,28 +382,28 @@ onEvent("loaded", e => {
 					output: Ingredient.of(output),
 
 					cookTime: cookTime
-				})
+				}).id(id)
 			}
 		},
 
 		botania: {
-			brew: (event, input, outputBrew) => {
+			brew: (event, input, outputBrew, id) => {
 				event.custom({
 					type: "botania:brew",
 
 					brew: outputBrew,
 					ingredients: ingredientsConvert(arrConvert(input))
-				})
+				}).id(id)
 			},
-			elven_trade: (event, input, output) => {
+			elven_trade: (event, input, output, id) => {
 				event.custom({
 					type: "botania:elven_trade",
 
 					ingredients: ingredientsConvert(arrConvert(input)),
 					output: ingredientsConvert(arrConvert(output))
-				})
+				}).id(id)
 			},
-			mana_infusion: (event, input, output, mana, catalyst) => {
+			mana_infusion: (event, input, output, mana, catalyst, id) => {
 				if (typeof mana!="number") mana = 1000
 
 				event.custom({
@@ -414,25 +414,25 @@ onEvent("loaded", e => {
 
 					mana: mana,
 					catalyst: typeof catalyst!="string" ? null : blockConvert(catalyst, true)
-				})
+				}).id(id)
 			},
-			petal_apothecary: (event, input, output) => {
+			petal_apothecary: (event, input, output, id) => {
 				event.custom({
 					type: "botania:petal_apothecary",
 
 					ingredients: ingredientsConvert(arrConvert(input)),
 					output: Ingredient.of(output)
-				})
+				}).id(id)
 			},
-			pure_daisy: (event, input, output) => {
+			pure_daisy: (event, input, output, id) => {
 				event.custom({
 					type: "botania:pure_daisy",
 
 					input: blockConvert(input, true),
 					output: {name: output}
-				})
+				}).id(id)
 			},
-			runic_altar: (event, input, output, mana) => {
+			runic_altar: (event, input, output, mana, id) => {
 				if (typeof mana!="number") mana = 5000
 
 				event.custom({
@@ -442,9 +442,9 @@ onEvent("loaded", e => {
 					output: Ingredient.of(output),
 
 					mana: mana
-				})
+				}).id(id)
 			},
-			terra_plate: (event, input, output, mana) => {
+			terra_plate: (event, input, output, mana, id) => {
 				if (typeof mana!="number") mana = 100000
 
 				event.custom({
@@ -454,12 +454,12 @@ onEvent("loaded", e => {
 					result: Ingredient.of(output),
 
 					mana: mana
-				})
+				}).id(id)
 			}
 		},
 
 		botanypots: {
-			crop: (event, inputSeed, SoilCategories, output, growthTicks, displayBlock) => {
+			crop: (event, inputSeed, SoilCategories, output, growthTicks, displayBlock, id) => {
 				if (typeof growthTicks!="number") growthTicks = 1200
 				if (typeof displayBlock!="string") displayBlock = inputSeed
 				let results = []
@@ -481,9 +481,9 @@ onEvent("loaded", e => {
 					categories: arrConvert(SoilCategories),
 					growthTicks: growthTicks,
 					display: blockConvert(displayBlock, false)
-				})
+				}).id(id)
 			},
-			fertilizer: (event, fertilizer, minTicks, maxTicks) => {
+			fertilizer: (event, fertilizer, minTicks, maxTicks, id) => {
 				if (typeof minTicks!="number") minTicks = 100
 				if (typeof maxTicks!="number") maxTicks = minTicks + 100
 
@@ -493,9 +493,9 @@ onEvent("loaded", e => {
 					fertilizer: Ingredient.of(fertilizer),
 					minTicks: minTicks,
 					maxTicks: maxTicks
-				})
+				}).id(id)
 			},
-			soil: (event, inputSoil, SoilCategories, growthModifier, displayBlock) => {
+			soil: (event, inputSoil, SoilCategories, growthModifier, displayBlock, id) => {
 				if (typeof growthModifier!="number") growthModifier = 0
 				if (typeof displayBlock!="string") displayBlock = inputSoil
 
@@ -507,12 +507,12 @@ onEvent("loaded", e => {
 					categories: arrConvert(SoilCategories),
 					growthModifier: growthModifier,
 					display: blockConvert(displayBlock, false)
-				})
+				}).id(id)
 			}
 		},
 		
 		draconicevolution: {
-			fusion_crafting: (event, mainInput, sideInput, output, tier, energy) => {
+			fusion_crafting: (event, mainInput, sideInput, output, tier, energy, id) => {
 				if (typeof tier!="string") tier = "DRACONIUM"
 				if (typeof energy!="number") energy = 100000
 				catalyst = Ingredient.of(mainInput)
@@ -533,12 +533,12 @@ onEvent("loaded", e => {
 
 					total_energy: energy,
 					tier: tier
-				})
+				}).id(id)
 			}
 		},
 		
 		divinerpg: {
-			arcanium_extractor: (event, input,  output, experience, time) => {
+			arcanium_extractor: (event, input,  output, experience, time, id) => {
 				if (typeof experience!="number") experience = 0.1
 				if (typeof time!="number") time = 200
 
@@ -550,7 +550,7 @@ onEvent("loaded", e => {
 					
 					experience: 0.1,
 					cookingtime: 100
-				})
+				}).id(id)
 			},
 			
 			infusion_table: (event, input, template, output) => {
@@ -561,12 +561,12 @@ onEvent("loaded", e => {
 					input: Ingredient.of(input),
 					template: Ingredient.of(template),
 					output: Ingredient.of(output)
-				})
+				}).id(id)
 			}
 		},
 
 		elementalcraft: {
-			binding: (event, input, output, elementType, elementAmount) => {
+			binding: (event, input, output, elementType, elementAmount, id) => {
 				if (typeof elementAmount!="number") elementAmount = 1000
 
 				event.custom({
@@ -577,9 +577,9 @@ onEvent("loaded", e => {
 
 					element_type: elementType,
 					element_amount: elementAmount
-				})
+				}).id(id)
 			},
-			crystallization: (event, input, output, elementType, elementAmount) => {
+			crystallization: (event, input, output, elementType, elementAmount, id) => {
 				input = ingredientsConvert(arrConvert(input))
 				if (typeof elementAmount!="number") elementAmount = 1000
 				let results = []
@@ -604,9 +604,9 @@ onEvent("loaded", e => {
 
 					element_type: elementType,
 					element_amount: elementAmount
-				})
+				}).id(id)
 			},
-			grinding: (event, input, output, elementAmount) => {
+			grinding: (event, input, output, elementAmount, id) => {
 				if (typeof elementAmount!="number") elementAmount = 1000
 
 				event.custom({
@@ -616,9 +616,9 @@ onEvent("loaded", e => {
 					output: Ingredient.of(output),
 
 					element_amount: elementAmount,
-				})
+				}).id(id)
 			},
-			tool_infusion: (event, input, toolInfusionType, elementAmount) => {
+			tool_infusion: (event, input, toolInfusionType, elementAmount, id) => {
 				if (typeof elementAmount!="number") elementAmount = 1000
 
 				event.custom({
@@ -628,9 +628,9 @@ onEvent("loaded", e => {
 
 					tool_infusion: toolInfusionType,
 					element_amount: elementAmount,
-				})
+				}).id(id)
 			},
-			infusion: (event, input, output, elementType, elementAmount) => {
+			infusion: (event, input, output, elementType, elementAmount, id) => {
 				if (typeof elementAmount!="number") elementAmount = 1000
 
 				event.custom({
@@ -641,9 +641,9 @@ onEvent("loaded", e => {
 
 					element_type: elementType,
 					element_amount: elementAmount,
-				})
+				}).id(id)
 			},
-			inscription: (event, input, output, elementType, elementAmount) => {
+			inscription: (event, input, output, elementType, elementAmount, id) => {
 				input = ingredientsConvert(arrConvert(input).slice(0, 4))
 				output = arrConvert(output)
 				let outputItem = Ingredient.of(output[0])
@@ -659,9 +659,9 @@ onEvent("loaded", e => {
 
 					element_type: elementType,
 					element_amount: elementAmount
-				})
+				}).id(id)
 			},
-			pureinfusion: (event, input, output, elementAmount) => {
+			pureinfusion: (event, input, output, elementAmount, id) => {
 				input = arrConvert(input).slice(0, 5)
 				if (typeof elementAmount!="number") elementAmount = 1000
 
@@ -672,9 +672,9 @@ onEvent("loaded", e => {
 					output: Ingredient.of(output),
 
 					element_amount: elementAmount,
-				})
+				}).id(id)
 			},
-			spell_craft: (event, input, output) => {
+			spell_craft: (event, input, output, id) => {
 				input = ingredientsConvert(arrConvert(input))
 				output = arrConvert(output)
 				let outputItem = Ingredient.of(output[0])
@@ -687,12 +687,12 @@ onEvent("loaded", e => {
 					gem: input[0],
 					crystal: input[1],
 					output: outputItem,
-				})
+				}).id(id)
 			}
 		},
 
 		evilcraft: {
-			blood_infuser: (event, inputItem, inputFluid, output, tier, time, experience) => {
+			blood_infuser: (event, inputItem, inputFluid, output, tier, time, experience, id) => {
 				if (typeof experience!="number") experience = 0.1
 				if (typeof tier!="number") tier = 0
 				if (typeof time!="number") time = 200
@@ -707,9 +707,9 @@ onEvent("loaded", e => {
 					duration: time,
 					xp: experience,
 					tier: tier
-				})
+				}).id(id)
 			},
-			environmental_accumulator: (event, input, inputAction, output, outputWeather, time, cooldownTime) => {
+			environmental_accumulator: (event, input, inputAction, output, outputWeather, time, cooldownTime, id) => {
 				if (typeof time!="number") time = 100
 				if (typeof cooldownTime!="number") cooldownTime = 0
 
@@ -725,12 +725,12 @@ onEvent("loaded", e => {
 					
 					duration: time,
 					cooldownTime: cooldownTime
-				})
+				}).id(id)
 			}
 		},
 		
 		ftbic: {
-			antimatter_boost: (event, input, boost) => {
+			antimatter_boost: (event, input, boost, id) => {
 				if (typeof boost!="number") boost = 1000
 
 				event.custom({
@@ -738,9 +738,9 @@ onEvent("loaded", e => {
 
 					ingredient: Ingredient.of(input),
 					boost: boost
-				})
+				}).id(id)
 			},
-			basic_generator_fuel: (event, input, ticks) => {
+			basic_generator_fuel: (event, input, ticks, id) => {
 				if (typeof ticks!="number") ticks = 200
 
 				event.custom({
@@ -748,36 +748,36 @@ onEvent("loaded", e => {
 
 					ingredient: Ingredient.of(input),
 					ticks: ticks
-				})
+				}).id(id)
 			},
-			canning: (event, input, output) => {
+			canning: (event, input, output, id) => {
 				input = arrConvert(input).slice(0, 2)
-				addFTBICRecipes(event, input, output, "ftbic:canning")
+				addFTBICRecipes(event, input, output, "ftbic:canning", id)
 			},
-			compressing: (event, input, output) => {
+			compressing: (event, input, output, id) => {
 				input = arrConvert(input)
-				addFTBICRecipes(event, input, output, "ftbic:compressing")
+				addFTBICRecipes(event, input, output, "ftbic:compressing", id)
 			},
-			extruding: (event, input, output) => {
+			extruding: (event, input, output, id) => {
 				input = arrConvert(input)
-				addFTBICRecipes(event, input, output, "ftbic:extruding")
+				addFTBICRecipes(event, input, output, "ftbic:extruding", id)
 			},
-			macerating: (event, input, output) => {
+			macerating: (event, input, output, id) => {
 				input = arrConvert(input)
-				addFTBICRecipes(event, input, output, "ftbic:macerating")
+				addFTBICRecipes(event, input, output, "ftbic:macerating", id)
 			},
-			rolling: (event, input, output) => {
+			rolling: (event, input, output, id) => {
 				input = arrConvert(input)
-				addFTBICRecipes(event, input, output, "ftbic:rolling")
+				addFTBICRecipes(event, input, output, "ftbic:rolling", id)
 			},
-			separating: (event, input, output) => {
+			separating: (event, input, output, id) => {
 				input = arrConvert(input)
-				addFTBICRecipes(event, input, output, "ftbic:separating")
+				addFTBICRecipes(event, input, output, "ftbic:separating", id)
 			}
 		},
 
 		industrialforegoing: {
-			dissolution_chamber: (event, input, inputFluid, output, outputFluid, time) => {
+			dissolution_chamber: (event, input, inputFluid, output, outputFluid, time, id) => {
 				input = arrConvert(input).slice(0, 8)
 				inputFluid = fluidConvert(inputFluid)
 				outputFluid = fluidConvert(outputFluid)
@@ -793,9 +793,9 @@ onEvent("loaded", e => {
 
 					output: Ingredient.of(output),
 					outputFluid: `{FluidName:"${outputFluid!=null ? outputFluid.id : ""}",Amount:${outputFluid!=null ? outputFluid.getAmount() : 0}}`
-				})
+				}).id(id)
 			},
-			fluid_extractor: (event, input, output, breakchance, result) => {
+			fluid_extractor: (event, input, output, breakchance, result, id) => {
 				output = fluidConvert(output)
 				if (typeof breakchance!="number") breakchance = 0
 				if (typeof result!="string") result = "minecraft:air"
@@ -809,9 +809,9 @@ onEvent("loaded", e => {
 
 					breakChance: breakchance,
 					defaultRecipe: false
-				})
+				}).id(id)
 			},
-			laser_drill: (event, output, catalyst, rarities, fluidRecipe, entity) => {
+			laser_drill: (event, output, catalyst, rarities, fluidRecipe, entity, id) => {
 				fluidRecipe ? output = fluidConvert(output) : output = Ingredient.of(output)
 				if (fluidRecipe!==true) fluidRecipe = false
 				if (typeof entity!="string") entity = "minecraft:empty"
@@ -856,9 +856,9 @@ onEvent("loaded", e => {
 				}
 				if (fluidRecipe) recipe["entity"] = entity
 
-				event.custom(recipe)
+				event.custom(recipe).id(id)
 			},
-			stonework_generate: (event, output, water, lava) => {
+			stonework_generate: (event, output, water, lava, id) => {
 				water = arrConvert(water)
 				lava = arrConvert(lava)
 				event.custom({
@@ -870,29 +870,29 @@ onEvent("loaded", e => {
 					waterConsume: typeof water[1]!="number" ? 0 : water[1],
 					lavaNeed: typeof lava[0]!="number" ? 1000 : lava[0],
 					lavaConsume: typeof lava[1]!="number" ? 0 : lava[1]
-				})
+				}).id(id)
 			}
 		},
 		
 		mysticalagriculture: {
-			infusion: (event, mainInput, sideInput, output) => {
+			infusion: (event, mainInput, sideInput, output, id) => {
 				event.custom({
 					type: "mysticalagriculture:infusion",
 					
 					input: Ingredient.of(mainInput),
 					ingredients: ingredientsConvert(arrConvert(sideInput).slice(0, 8)),
 					result: Ingredient.of(output)
-				})
+				}).id(id)
 			},
-			reprocessor: (event, input, output) => {
+			reprocessor: (event, input, output, id) => {
 				event.custom({
 					type: "mysticalagriculture:reprocessor",
 
 					input: Ingredient.of(input),
 					result: Ingredient.of(output)
-				})
+				}).id(id)
 			},
-			soul_extraction: (event, input, soulType, soulAmount) => {
+			soul_extraction: (event, input, soulType, soulAmount, id) => {
 				if (typeof soulAmount!="number") soulAmount = 1
 				
 				event.custom({
@@ -902,12 +902,12 @@ onEvent("loaded", e => {
 						type: soulType,
 						souls: soulAmount
 					}
-				})
+				}).id(id)
 			}
 		},
 
 		pneumaticcraft: {
-			amadron: (event, input, output) => {
+			amadron: (event, input, output, id) => {
 				input = arrConvert(input)
 				output = arrConvert(output)
 				let inputFluid = input[1] !== true
@@ -929,9 +929,9 @@ onEvent("loaded", e => {
 
 					static: true,
 					level: 0
-				})
+				}).id(id)
 			},
-			assembly_laser: (event, input, output, isDrill) => {
+			assembly_laser: (event, input, output, isDrill, id) => {
 				let recipe = {
 					type: "pneumaticcraft:assembly_laser",
 
@@ -946,9 +946,9 @@ onEvent("loaded", e => {
 
 				if (Ingredient.of(input).getCount()!==1) recipe["input"]["type"] = "pneumaticcraft:stacked_item"
 
-				event.custom(recipe)
+				event.custom(recipe).id(id)
 			},
-			explosion_crafting: (event, input, output, loss_rate) => {
+			explosion_crafting: (event, input, output, loss_rate, id) => {
 				if (typeof loss_rate!="number") loss_rate = 20
 
 				event.custom({
@@ -958,9 +958,9 @@ onEvent("loaded", e => {
 					results: ingredientsConvert(arrConvert(output)),
 
 					loss_rate: loss_rate
-				})
+				}).id(id)
 			},
-			heat_frame_cooling: (event, input, output, max_temp, bonusOutput) => {
+			heat_frame_cooling: (event, input, output, max_temp, bonusOutput, id) => {
 				input = arrConvert(input)
 				if (typeof max_temp!="number") max_temp = 273
 				if (!Array.isArray(bonusOutput)) bonusOutput = []
@@ -978,9 +978,9 @@ onEvent("loaded", e => {
 						multiplier: bonusOutput[0],
 						limit: bonusOutput[1]
 					}
-				})
+				}).id(id)
 			},
-			heat_properties: (event, input, output, temperature, thermalResistance, heatCapacity) => {
+			heat_properties: (event, input, output, temperature, thermalResistance, heatCapacity, id) => {
 				output = arrConvert(output)
 				if (typeof temperature!="number") temperature = 298
 				if (typeof thermalResistance!="number") thermalResistance = 200
@@ -997,9 +997,9 @@ onEvent("loaded", e => {
 				if (output[0]!=="" && output[0]!=="minecraft:air") recipe["transformCold"] = {block: output[0]}
 				if (output[1]!=="" && output[1]!=="minecraft:air") recipe["transformHot"] = {block: output[1]}
 
-				event.custom(recipe)
+				event.custom(recipe).id(id)
 			},
-			fluid_mixer: (event, input1, input2, outputFluid, outputItem, pressure, time) => {
+			fluid_mixer: (event, input1, input2, outputFluid, outputItem, pressure, time, id) => {
 				outputFluid = fluidConvert(outputFluid)
 				outputItem = Ingredient.of(outputItem)
 				input1 = arrConvert(input1)
@@ -1020,9 +1020,9 @@ onEvent("loaded", e => {
 				if (outputFluid!=null && outputFluid.id!=="minecraft:empty") recipe["fluid_output"] = outputFluid
 				if (outputItem!=null && outputItem.id!=="minecraft:air") recipe["item_output"] = outputItem
 
-				event.custom(recipe)
+				event.custom(recipe).id(id)
 			},
-			fuel_quality: (event, input, air_per_bucket, burn_rate) => {
+			fuel_quality: (event, input, air_per_bucket, burn_rate, id) => {
 				input = arrConvert(input)
 				if (typeof air_per_bucket!="number") air_per_bucket = 100000
 				if (typeof burn_rate!="number") burn_rate = 1
@@ -1034,9 +1034,9 @@ onEvent("loaded", e => {
 
 					air_per_bucket: air_per_bucket,
 					burn_rate: burn_rate
-				})
+				}).id(id)
 			},
-			pressure_chamber: (event, input, output, pressure) => {
+			pressure_chamber: (event, input, output, pressure, id) => {
 				if (typeof pressure!="number") pressure = 1
 
 				input = ingredientsConvert(arrConvert(input))
@@ -1047,7 +1047,7 @@ onEvent("loaded", e => {
 					}
 					if (item.getCount()!==1) itemJson["type"] = "pneumaticcraft:stacked_item"
 					input[input.indexOf(item)] = itemJson
-				})
+				}).id(id)
 
 				event.custom({
 					type: "pneumaticcraft:pressure_chamber",
@@ -1056,9 +1056,9 @@ onEvent("loaded", e => {
 					results: ingredientsConvert(arrConvert(output)),
 
 					pressure: pressure
-				})
+				}).id(id)
 			},
-			refinery: (event, input, output, temperature) => {
+			refinery: (event, input, output, temperature, id) => {
 				input = arrConvert(input)
 
 				let temperatures = {}
@@ -1072,9 +1072,9 @@ onEvent("loaded", e => {
 					results: fluidsConvert(arrConvert(output).slice(0, 4)),
 
 					temperature: temperatures,
-				})
+				}).id(id)
 			},
-			thermo_plant: (event, inputItem, inputFluid, outputItem, outputFluid, temperature, pressure, speed, exothermic) => {
+			thermo_plant: (event, inputItem, inputFluid, outputItem, outputFluid, temperature, pressure, speed, exothermic, id) => {
 				inputItem = Ingredient.of(inputItem)
 				let itemJson = {item: inputItem.id, count: inputItem.getCount()}
 				if (inputItem.getCount()!==1) inputItem = Object.assign(itemJson, {type: "pneumaticcraft:stacked_item"})
@@ -1109,12 +1109,12 @@ onEvent("loaded", e => {
 
 				if (typeof pressure=="number") recipe["pressure"] = pressure
 
-				event.custom(recipe)
+				event.custom(recipe).id(id)
 			}
 		},
 
 		powah: {
-			energizing: (event, input, output, energy) => {
+			energizing: (event, input, output, energy, id) => {
 				input = arrConvert(input).slice(0, 6)
 				if (typeof energy!="number") energy = 100
 
@@ -1125,12 +1125,12 @@ onEvent("loaded", e => {
 					result: Ingredient.of(output),
 
 					energy: energy
-				})
+				}).id(id)
 			}
 		},
 		
 		psi: {
-			trick_crafting: (event, input, output, cad, trick, dimension) => {
+			trick_crafting: (event, input, output, cad, trick, dimension, id) => {
 				let recipe = {
 					type: typeof dimension=="string" && dimension!=="" ? "psi:dimension_trick_crafting" : "psi:trick_crafting",
 					
@@ -1142,31 +1142,31 @@ onEvent("loaded", e => {
 				if (typeof trick=="string" && trick!=="") recipe["trick"] = trick
 				if (recipe["type"]==="psi:dimension_trick_crafting") recipe["dimension"] = dimension
 				
-				event.custom(recipe)
+				event.custom(recipe).id(id)
 			}
 		},
 		
 		silentgear: {
-			compounding: (event, input, output, isGem) => {
+			compounding: (event, input, output, isGem, id) => {
 				event.custom({
 					type: isGem===true ? "silentgear:compounding/gem" : "silentgear:compounding/metal",
 					
 					ingredients: ingredientsConvert(arrConvert(input).slice(0, 4)),
 					result: Ingredient.of(output)
-				})
+				}).id(id)
 			},
-			salvaging: (event, input, output) => {
+			salvaging: (event, input, output, id) => {
 				event.custom({
 					type: "silentgear:salvaging",
 					
 					ingredient: Ingredient.of(input),
 					results: ingredientsConvert(arrConvert(output).slice(0, 9))
-				})
+				}).id(id)
 			}
 		},
 
 		silents_mechanisms: {
-			alloy_smelting: (event, input, output, time) => {
+			alloy_smelting: (event, input, output, time, id) => {
 				input = arrConvert(input).slice(0, 4)
 				let ingredients = []
 				input.forEach(item => {
@@ -1174,16 +1174,7 @@ onEvent("loaded", e => {
 				})
 
 				if (typeof time!="number") time = 200
-
-				console.log({
-					type: "silents_mechanisms:alloy_smelting",
-
-					ingredients: ingredients,
-					result: Ingredient.of(output),
-
-					process_time: time
-				})
-
+				
 				event.custom({
 					type: "silents_mechanisms:alloy_smelting",
 
@@ -1191,9 +1182,9 @@ onEvent("loaded", e => {
 					result: Ingredient.of(output),
 
 					process_time: time
-				})
+				}).id(id)
 			},
-			compressing: (event, input, output, time) => {
+			compressing: (event, input, output, time, id) => {
 				if (typeof time!="number") time = 200
 
 				event.custom({
@@ -1203,9 +1194,9 @@ onEvent("loaded", e => {
 					result: Ingredient.of(output).toJson(),
 
 					process_time: time
-				})
+				}).id(id)
 			},
-			crushing: (event, input, output, time) => {
+			crushing: (event, input, output, time, id) => {
 				output = arrConvert(output).slice(0, 4)
 				if (typeof time!="number") time = 200
 
@@ -1216,9 +1207,9 @@ onEvent("loaded", e => {
 					results: ingredientsConvert(output),
 
 					process_time: time
-				})
+				}).id(id)
 			},
-			drying: (event, input, output, time) => {
+			drying: (event, input, output, time, id) => {
 				if (typeof time!="number") time = 200
 
 				event.custom({
@@ -1228,9 +1219,9 @@ onEvent("loaded", e => {
 					result: Ingredient.of(output).toJson(),
 
 					process_time: time
-				})
+				}).id(id)
 			},
-			infusing: (event, inputItem, inputFluid, output, time) => {
+			infusing: (event, inputItem, inputFluid, output, time, id) => {
 				inputFluid = arrConvert(inputFluid)
 				if (typeof time!="number") time = 200
 
@@ -1242,9 +1233,9 @@ onEvent("loaded", e => {
 					result: Ingredient.of(output).toJson(),
 
 					process_time: time
-				})
+				}).id(id)
 			},
-			mixing: (event, input, output, time) => {
+			mixing: (event, input, output, time, id) => {
 				if (typeof time!="number") time = 200
 
 				event.custom({
@@ -1254,9 +1245,9 @@ onEvent("loaded", e => {
 					result: fluidConvert(output).toJson(),
 
 					process_time: time
-				})
+				}).id(id)
 			},
-			refining: (event, input, output, time) => {
+			refining: (event, input, output, time, id) => {
 				input = arrConvert(input)
 				if (typeof time!="number") time = 200
 
@@ -1267,9 +1258,9 @@ onEvent("loaded", e => {
 					results: fluidsConvert(arrConvert(output).slice(0, 4)),
 
 					process_time: time
-				})
+				}).id(id)
 			},
-			solidifying: (event, input, output, time) => {
+			solidifying: (event, input, output, time, id) => {
 				input = arrConvert(input)
 				if (typeof time!="number") time = 200
 
@@ -1280,12 +1271,12 @@ onEvent("loaded", e => {
 					result: Ingredient.of(output),
 
 					process_time: time
-				})
+				}).id(id)
 			}
 		},
 
 		tconstruct: {
-			alloy: (event, input, output, temperature) => {
+			alloy: (event, input, output, temperature, id) => {
 				if (typeof temperature!="number") temperature = 100
 
 				event.custom({
@@ -1295,9 +1286,9 @@ onEvent("loaded", e => {
 					result: fluidConvert(output).toJson(),
 
 					temperature: temperature
-				})
+				}).id(id)
 			},
-			casting: (event, inputFluid, inputCast, output, isBasin, castConsumed, time) => {
+			casting: (event, inputFluid, inputCast, output, isBasin, castConsumed, time, id) => {
 				inputFluid = arrConvert(inputFluid)
 				inputCast = Ingredient.of(inputCast)
 				if (typeof time!="number") time = 60
@@ -1314,9 +1305,9 @@ onEvent("loaded", e => {
 				
 				if (inputCast.id!=="minecraft:air") recipe["cast"] = inputCast.toJson()
 				
-				event.custom(recipe)
+				event.custom(recipe).id(id)
 			},
-			entity_melting: (event, entity, output, damage) => {
+			entity_melting: (event, entity, output, damage, id) => {
 				if (typeof damage!="number") damage = 1
 				
 				event.custom({
@@ -1326,9 +1317,9 @@ onEvent("loaded", e => {
 					result: fluidConvert(output).toJson(),
 
 					damage: damage
-				})
+				}).id(id)
 			},
-			melting: (event, input, output, temperature, time) => {
+			melting: (event, input, output, temperature, time, id) => {
 				if (typeof temperature!="number") temperature = 100
 				if (typeof time!="number") time = 300	
 
@@ -1340,18 +1331,18 @@ onEvent("loaded", e => {
 					
 					temperature:  temperature,
 					time: time
-				})
+				}).id(id)
 			},
-			molding_table: (event, inputCast, inputPattern, outputCast) => {
+			molding_table: (event, inputCast, inputPattern, outputCast, id) => {
 				event.custom({
 					type: "tconstruct:molding_table",
 					
 					material: Ingredient.of(inputCast),
 					pattern: Ingredient.of(inputPattern),
 					result: Ingredient.of(outputCast)
-				})
+				}).id(id)
 			},
-			part_builder: (event, pattern, output, materialCost) => {
+			part_builder: (event, pattern, output, materialCost, id) => {
 				if (typeof materialCost!="number") materialCost = 1	
 
 				event.custom({
@@ -1361,7 +1352,7 @@ onEvent("loaded", e => {
 					result: {item: Ingredient.of(output).id},
 
 					cost: materialCost,
-				})
+				}).id(id)
 			},
 			severing: (event, entity, output) => {
 				event.custom({
@@ -1369,9 +1360,9 @@ onEvent("loaded", e => {
 					
 					entity: {type: entity},
 					result: Ingredient.of(output)
-				})
+				}).id(id)
 			},
-			table_casting_material: (event, inputCast, output, materialCost) => {
+			table_casting_material: (event, inputCast, output, materialCost, id) => {
 				if (typeof materialCost!="number") materialCost = 1	
 
 				event.custom({
@@ -1381,7 +1372,7 @@ onEvent("loaded", e => {
 					result: Ingredient.of(output).id,
 					
 					item_cost: materialCost
-				})
+				}).id(id)
 			}
 		}
 	}

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -22,6 +22,26 @@ function blockIngredientsConvert(i, withType) {
 	i.forEach(block => {ingredients.push(blockConvert(block, withType))})
 	return ingredients
 }
+function addFTBICRecipes(event, input, output, type) {
+	let ingredients = []
+	input.forEach(item => {
+		let ingredient = Ingredient.of(item)
+		let ingredientJson = {ingredient: {item: ingredient.id}, count: ingredient.getCount()}
+		
+		if (ingredient.nbt!=null){
+			ingredientJson["ingredient"]["type"] = "forge:nbt"
+			ingredientJson["ingredient"]["nbt"] = String(ingredient.nbt)
+		}
+		ingredients.push(ingredientJson)
+	})
+
+	event.custom({
+		type: type,
+
+		inputItems: ingredients,
+		outputItems: ingredientsConvert(arrConvert(output))
+	})
+}
 
 let i
 
@@ -423,6 +443,53 @@ onEvent("loaded", e => {
 					crystal: input[1],
 					output: outputItem,
 				})
+			}
+		},
+
+		ftbic: {
+			antimatter_boost: (event, input, boost) => {
+				if (typeof boost!=="number") boost = 1000
+
+				event.custom({
+					type: "ftbic:antimatter_boost",
+					
+					ingredient: Ingredient.of(input),
+					boost: boost
+				})
+			},
+			basic_generator_fuel: (event, input, ticks) => {
+				if (typeof ticks!=="number") ticks = 200
+
+				event.custom({
+					type: "ftbic:basic_generator_fuel",
+					
+					ingredient: Ingredient.of(input),
+					ticks: ticks
+				})
+			},
+			canning: (event, input, output) => {
+				input = arrConvert(input).slice(0, 2)
+				addFTBICRecipes(event, input, output, "ftbic:canning")
+			},
+			compressing: (event, input, output) => {
+				input = arrConvert(input)
+				addFTBICRecipes(event, input, output, "ftbic:compressing")
+			},
+			extruding: (event, input, output) => {
+				input = arrConvert(input)
+				addFTBICRecipes(event, input, output, "ftbic:extruding")
+			},
+			macerating: (event, input, output) => {
+				input = arrConvert(input)
+				addFTBICRecipes(event, input, output, "ftbic:macerating")
+			},
+			rolling: (event, input, output) => {
+				input = arrConvert(input)
+				addFTBICRecipes(event, input, output, "ftbic:rolling")
+			},
+			separating: (event, input, output) => {
+				input = arrConvert(input)
+				addFTBICRecipes(event, input, output, "ftbic:separating")
 			}
 		},
 

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -222,6 +222,59 @@ onEvent("loaded", e => {
 			}
 		},
 		
+		botanypots: {
+			crop: (event, inputSeed, SoilCategories, output, growthTicks, displayBlock) => {
+				if (growthTicks==null) growthTicks = 1200
+				if (displayBlock==null) displayBlock = inputSeed
+				let results = []
+				output.forEach(roll => {
+					results.push({
+						output: Ingredient.of(roll[0]),
+						chance: typeof roll[1]==='undefined' ? 1 : roll[1],
+						minRolls: typeof roll[2]==='undefined' ? 1 : roll[2],
+						maxRolls: typeof roll[3]==='undefined' ? 1 : roll[3]
+					})
+				})
+
+				event.custom({
+				   	type: "botanypots:crop",
+					
+					seed: Ingredient.of(inputSeed).id,
+					results: results,
+					
+				    categories: arrConvert(SoilCategories),
+				   	growthTicks: growthTicks,
+				   	display: blockConvert(displayBlock)
+				})
+			},
+			fertilizer: (event, fertilizer, minTicks, maxTicks) => {
+				if (minTicks==null) minTicks = 100
+				if (maxTicks==null) maxTicks = minTicks + 100
+
+				event.custom({
+					type: "botanypots:fertilizer",
+					
+					fertilizer: Ingredient.of(fertilizer),
+					minTicks: minTicks,
+					maxTicks: maxTicks
+				})
+			},
+			soil: (event, inputSoil, SoilCategories, growthModifier, displayBlock) => {
+				if (growthModifier==null) growthModifier = 0
+				if (displayBlock==null) displayBlock = inputSoil
+
+				event.custom({
+					type: "botanypots:soil",
+					
+					input: Ingredient.of(inputSoil),
+					
+					categories: arrConvert(SoilCategories),
+					growthModifier: growthModifier,
+					display: blockConvert(displayBlock)
+				})
+			}
+		},
+		
 		powah: {
 			energizing: (event, input, output, energy) => {
 				input = arrConvert(input).slice(0, 6)

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -197,17 +197,17 @@ onEvent("loaded", e => {
 				})
 			}
 		},
-		
+
 		atum: {
 			kiln: (event, input, output, experience) => {
 				if (typeof experience!="number") experience = 0.1
 
 				event.custom({
 					type: "atum:kiln",
-					
+
 					ingredient: Ingredient.of(input),
 					result: Ingredient.of(output),
-					
+
 					experience: experience
 				})
 			},
@@ -237,6 +237,59 @@ onEvent("loaded", e => {
 			}
 		},
 
+		betterendforge: {
+			alloying: (event, input, output, experience, time) => {
+				if (typeof experience!="number") experience = 1
+				if (typeof time!="number") time = 200
+
+				event.custom({
+					type: "betterendforge:alloying",
+
+					ingredients: ingredientsConvert(arrConvert(input).slice(0, 2)),
+					result: Ingredient.of(output),
+
+					experience: experience,
+					smelttime: time
+				})
+			},
+			anvil_smithing: (event, input, output, toolLevel, anvilLevel, toolDamage) => {
+				if (typeof toolLevel!="number") toolLevel = 0
+				if (typeof anvilLevel!="number") anvilLevel = 1
+				if (typeof toolDamage!="number") toolDamage = 1
+
+				event.custom({
+					type: "betterendforge:anvil_smithing",
+
+					input: Ingredient.of(input),
+					result: Ingredient.of(output).id,
+
+					level: toolLevel,
+					anvilLevel: anvilLevel,
+					damage: toolDamage
+				})
+			},
+			infusion: (event, middleInput, catalystInput, output, time) => {
+				catalystInput = arrConvert(catalystInput).slice(0, 8)
+				let catalysts = []
+				for (i = 0; i < catalystInput.length; i++) {
+					if (Ingredient.of(catalystInput[i]).id!=="minecraft:air") {
+						catalysts.push({item: Ingredient.of(catalystInput[i]), index: i})
+					}
+				}
+				if (typeof time!="number") time = 100
+
+				event.custom({
+					type: "betterendforge:infusion",
+					
+					input: Ingredient.of(middleInput),
+					output: Ingredient.of(output).id,
+					catalysts: catalysts,
+					
+					time: time
+				})
+			}
+		},
+		
 		boss_tools: {
 			blasting: (event, input, output, cookTime) => {
 				if (typeof cookTime!="number") cookTime = 200

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -11,18 +11,15 @@ function fluidConvert(i) {
 	if (typeof i == "string") i = Fluid.of(i, 1000)
 	return i
 }
-function blockConvert(i) {
-	i.substring(0, 1)==="#" ? i = {tag: i.substring(1)} : i = {block: i}
-	return i
-}
-function blockConvertWithType(i) {
-	let block = blockConvert(i)
-	i.substring(0, 1)==="#" ? block["type"] = "tag" : block["type"] = "block"
+function blockConvert(i, withType) {
+	let block
+	i.substring(0, 1)==="#" ? block = {tag: i.substring(1)} : block = {block: i}
+	if (withType) i.substring(0, 1)==="#" ? block["type"] = "tag" : block["type"] = "block"
 	return block
 }
-function blockIngredientsConvert(i) {
+function blockIngredientsConvert(i, withType) {
 	let ingredients = []
-	i.forEach(block => {ingredients.push(blockConvert(block))})
+	i.forEach(block => {ingredients.push(blockConvert(block, withType))})
 	return ingredients
 }
 
@@ -74,7 +71,7 @@ onEvent("loaded", e => {
 				event.custom({
 					type: "astralsorcery:block_transmutation",
 
-					input: blockIngredientsConvert(arrConvert(input)),
+					input: blockIngredientsConvert(arrConvert(input), false),
 					output: {block: output},
 
 					starlight: starlight
@@ -177,7 +174,7 @@ onEvent("loaded", e => {
 					output: Ingredient.of(output),
 
 					mana: mana,
-					catalyst: catalyst==null ? null : blockConvertWithType(catalyst)
+					catalyst: catalyst==null ? null : blockConvert(catalyst, true)
 				})
 			},
 			petal_apothecary: (event, input, output) => {
@@ -192,7 +189,7 @@ onEvent("loaded", e => {
 				event.custom({
 					type: "botania:pure_daisy",
 
-					input: blockConvertWithType(input),
+					input: blockConvert(input, true),
 					output: {name: output}
 				})
 			},
@@ -244,7 +241,7 @@ onEvent("loaded", e => {
 					
 				    categories: arrConvert(SoilCategories),
 				   	growthTicks: growthTicks,
-				   	display: blockConvert(displayBlock)
+				   	display: blockConvert(displayBlock, false)
 				})
 			},
 			fertilizer: (event, fertilizer, minTicks, maxTicks) => {
@@ -270,7 +267,7 @@ onEvent("loaded", e => {
 					
 					categories: arrConvert(SoilCategories),
 					growthModifier: growthModifier,
-					display: blockConvert(displayBlock)
+					display: blockConvert(displayBlock, false)
 				})
 			}
 		},

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -81,14 +81,8 @@ onEvent("loaded", e => {
 			infuser: (event, input, output, duration, consumptionChance, settings, inputFluid) => {
 				if (duration==null) duration = 100
 				if (consumptionChance==null) consumptionChance = 0.1
-				if (settings==null) {
-					settings = [false, true, false]
-				} else {
-					settings = arrConvert(settings)
-					for (i = 0; i < 3; i++) {
-						if (typeof settings[i]==='undefined') settings.push([false, true, false][i])
-					}
-				}
+				if (settings==null) settings = [false, true, false]
+				settings = settings.concat([false, true, false].slice(settings.length, 3))
 				if (inputFluid==null) inputFluid = "astralsorcery:liquid_starlight"
 				
 				event.custom({

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -441,6 +441,33 @@ onEvent("loaded", e => {
 				})
 			}
 		},
+		
+		draconicevolution: {
+			fusion_crafting: (event, mainInput, sideInput, output, tier, energy) => {
+				if (typeof tier!="string") tier = "DRACONIUM"
+				if (typeof energy!="number") energy = 100000
+				catalyst = Ingredient.of(mainInput)
+				if (catalyst.getCount() > 1) {
+					catalyst = {
+						type: "draconicevolution:ingredient_stack",
+						items: [catalyst],
+						count: catalyst.getCount()
+					}
+				}
+				
+				
+				event.custom({
+					type: "draconicevolution:fusion_crafting",
+
+					catalyst: catalyst,
+					ingredients: ingredientsConvert(arrConvert(sideInput)),
+					result: Ingredient.of(output),
+
+					total_energy: energy,
+					tier: tier
+				})
+			}
+		},
 
 		elementalcraft: {
 			binding: (event, input, output, elementType, elementAmount) => {

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -78,6 +78,27 @@ let i
 
 onEvent("loaded", e => {
 	global.more_recipe_types = {
+		aoa3: {
+			infusion: (event, mainInput, input, output) => {
+				event.custom({
+					type: "aoa3:infusion",
+
+					input: Ingredient.of(mainInput),
+					ingredients: ingredientsConvert(arrConvert(input).slice(0, 9)),
+					result: Ingredient.of(output)
+				})
+			},
+			upgrade_kit: (event, input, upgradeKit, output) => {
+				event.custom({
+					type: "aoa3:upgrade_kit",
+
+					input: Ingredient.of(input),
+					upgrade_kit: Ingredient.of(upgradeKit),
+					result: Ingredient.of(output)
+				})
+			}
+		},
+		
 		appliedenergistics2: {
 			grinder: (event, input, output, turns) => {
 				output = ingredientsConvert(arrConvert(output).slice(0, 3))

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -82,6 +82,7 @@ onEvent("loaded", e => {
 				if (duration==null) duration = 100
 				if (consumptionChance==null) consumptionChance = 0.1
 				if (settings==null) settings = [false, true, false]
+				settings = settings.slice(0, 3)
 				settings = settings.concat([false, true, false].slice(settings.length, 3))
 				if (inputFluid==null) inputFluid = "astralsorcery:liquid_starlight"
 				

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -31,7 +31,8 @@ onEvent("loaded", e => {
 			grinder: (event, input, output, turns) => {
 				output = ingredientsConvert(arrConvert(output).slice(0, 3))
 				if (turns==null) turns = 4
-
+				console.log(Ingredient.of(input))
+				
 				event.custom({
 					type: "appliedenergistics2:grinder",
 
@@ -207,7 +208,7 @@ onEvent("loaded", e => {
 			},
 			terra_plate: (event, input, output, mana) => {
 				if (mana==null) mana = 100000
-
+				
 				event.custom({
 					type: "botania:terra_plate",
 
@@ -272,10 +273,136 @@ onEvent("loaded", e => {
 			}
 		},
 		
+		elementalcraft: {
+			binding: (event, input, output, elementType, elementAmount) => {
+				if (elementAmount==null) elementAmount = 1000
+
+				event.custom({
+					type: "elementalcraft:binding",
+					
+					ingredients: ingredientsConvert(arrConvert(input)),
+					output: Ingredient.of(output),
+					
+					element_type: elementType,
+					element_amount: elementAmount
+				})
+			},
+			crystallization: (event, input, output, elementType, elementAmount) => {
+				input = ingredientsConvert(arrConvert(input))
+				if (elementAmount==null) elementAmount = 1000
+				let results = []
+				output.forEach(result => {
+					let resultItem = Ingredient.of(result[0])
+					results.push({
+						result: {id: resultItem.id, Count: resultItem.getCount()},
+						weight: typeof result[1]==='undefined' ? 1 : result[1],
+						quality: typeof result[2]==='undefined' ? null : result[2]
+					})
+				})
+				
+				event.custom({
+					type: "elementalcraft:crystallization",
+					
+					ingredients: {
+						gem: input[0],
+						crystal: input[1],
+						shard: input[2]
+					},
+					outputs: results,
+					
+					element_type: elementType,
+					element_amount: elementAmount
+				})
+			},
+			grinding: (event, input, output, elementAmount) => {
+				if (elementAmount==null) elementAmount = 1000
+
+				event.custom({
+					type: "elementalcraft:grinding",
+					
+					input: Ingredient.of(input),
+					output: Ingredient.of(output),
+					
+					element_amount: elementAmount,
+				})
+			},
+			tool_infusion: (event, input, toolInfusionType, elementAmount) => {
+				if (elementAmount==null) elementAmount = 1000
+
+				event.custom({
+					type: "elementalcraft:tool_infusion",
+					
+					input: Ingredient.of(input),
+					
+					tool_infusion: toolInfusionType,
+					element_amount: elementAmount,
+				})
+			},
+			infusion: (event, input, output, elementType, elementAmount) => {
+				if (elementAmount==null) elementAmount = 1000
+
+				event.custom({
+					type: "elementalcraft:infusion",
+
+					input: Ingredient.of(input),
+					output: Ingredient.of(output),
+
+					element_type: elementType,
+					element_amount: elementAmount,
+				})
+			},
+			inscription: (event, input, output, elementType, elementAmount) => {
+				input = ingredientsConvert(arrConvert(input).slice(0, 4))
+				output = arrConvert(output)
+				let outputItem = Ingredient.of(output[0])
+				if (typeof output[1]!=='undefined') outputItem["nbt"] = output[1]
+				if (elementAmount==null) elementAmount = 1000
+
+				event.custom({
+					type: "elementalcraft:inscription",
+					
+					slate: input[0],
+					ingredients: input.slice(1),
+					output: outputItem,
+					
+					element_type: elementType,
+					element_amount: elementAmount
+				})
+			},
+			pureinfusion: (event, input, output, elementAmount) => {
+				input = arrConvert(input).slice(0, 5)
+				if (elementAmount==null) elementAmount = 1000
+
+				event.custom({
+					type: "elementalcraft:pureinfusion",
+
+					ingredients: ingredientsConvert(input),
+					output: Ingredient.of(output),
+
+					element_amount: elementAmount,
+				})
+			},
+			spell_craft: (event, input, output) => {
+				input = ingredientsConvert(arrConvert(input))
+				output = arrConvert(output)
+				let outputItem = Ingredient.of(output[0])
+				if (typeof output[1]!=='undefined') outputItem["nbt"] = output[1]
+
+				
+				event.custom({
+					type: "elementalcraft:spell_craft",
+					
+					gem: input[0],
+					crystal: input[1],
+					output: outputItem,
+				})
+			}
+		},
+		
 		powah: {
 			energizing: (event, input, output, energy) => {
 				input = arrConvert(input).slice(0, 6)
-				if (energy==null) energy=100
+				if (energy==null) energy = 100
 
 				event.custom({
 					type: "powah:energizing",

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -2,8 +2,12 @@ function arrConvert(i) {
 	if (!Array.isArray(i)) i = [i]
 	return i
 }
-function ingredientOfOnlyId(i) {
-	return i.substring(0, 1)==="#" ? {tag: Ingredient.of(i).id} : {item: Ingredient.of(i).id}
+function ingredientOfNoCount(i) {
+	item = Ingredient.of(i)
+	json = i.substring(0, 1)==="#" ? {tag: item.id} : {item: item.id}
+	if (item.getNbt()!=null) json["nbt"] = item.getNbt()
+	if (item.getChance()!=NaN) json["chance"] = item.getChance()
+	return json
 }
 function ingredientsConvert(i) {
 	let ingredients = []
@@ -144,14 +148,14 @@ onEvent("loaded", e => {
 				let recipe = {
 					type: "ars_nouveau:enchanting_apparatus",
 
-					reagent: [ingredientOfOnlyId(mainInput)],
+					reagent: [ingredientOfNoCount(mainInput)],
 					output: Ingredient.of(output)
 				}
 
 				sideInput = arrConvert(sideInput)
 				for (i = 0; i < sideInput.length; i++) {
 					if (Ingredient.of(sideInput[i]).id!=="minecraft:air") {
-						recipe[`item_${i + 1}`] = [ingredientOfOnlyId(sideInput[i])]
+						recipe[`item_${i + 1}`] = [ingredientOfNoCount(sideInput[i])]
 					}
 				}
 
@@ -712,10 +716,10 @@ onEvent("loaded", e => {
 				event.custom({
 					type: "evilcraft:environmental_accumulator",
 					
-					item: Ingredient.of(input).id,
+					item: Ingredient.of(input),
 					weather: inputAction,
 					result: {
-						item: Ingredient.of(output).id,
+						item: Ingredient.of(output),
 						weather: outputWeather
 					},
 					
@@ -1283,7 +1287,7 @@ onEvent("loaded", e => {
 					type: isBasin===true ? "tconstruct:casting_basin" : "tconstruct:casting_table",
 
 					fluid: fluidConvertWithTag(inputFluid[0], inputFluid[1], "name"),
-					result: Ingredient.of(output).id,
+					result: Ingredient.of(output),
 					
 					cooling_time: time,
 					cast_consumed: castConsumed===true
@@ -1312,7 +1316,7 @@ onEvent("loaded", e => {
 				event.custom({
 					type: "tconstruct:melting",
 					
-					ingredient: Ingredient.of(input).toJson(),
+					ingredient: ingredientOfNoCount(input),
 					result: fluidConvert(output).toJson(),
 					
 					temperature:  temperature,
@@ -1324,8 +1328,8 @@ onEvent("loaded", e => {
 					type: "tconstruct:molding_table",
 					
 					material: Ingredient.of(inputCast),
-					pattern: Ingredient.of(inputPattern).toJson(),
-					result: Ingredient.of(outputCast).id
+					pattern: Ingredient.of(inputPattern),
+					result: Ingredient.of(outputCast)
 				})
 			},
 			part_builder: (event, pattern, output, materialCost) => {
@@ -1354,7 +1358,7 @@ onEvent("loaded", e => {
 				event.custom({
 					type: "tconstruct:table_casting_material",
 					
-					cast: Ingredient.of(inputCast).toJson(),
+					cast: ingredientOfNoCount(inputCast),
 					result: Ingredient.of(output).id,
 					
 					item_cost: materialCost

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -14,6 +14,43 @@ function fluidConvert(i) {
 
 onEvent("loaded", e => {
 	global.more_recipe_types = {
+		appliedenergistics2: {
+			grinder: (event, input, output, turns) => {
+				output = ingredientsConvert(arrConvert(output).slice(0, 3))
+				if (turns==null) turns=4
+
+				event.custom({
+					type: "appliedenergistics2:grinder",
+
+					input: Ingredient.of(input),
+					result: {
+						primary: output[0],
+						optional: output.slice(1, 3)
+					},
+
+					turns: turns
+				})
+			},
+			inscriber: (event, input, output, keep) => {
+				input = ingredientsConvert(arrConvert(input).slice(0, 3))
+				input_names = ["top", "middle", "bottom"]
+				ingredients = {}
+				for (let i = 0; i < input.length; i++) {
+					if (input[i] != "" && input[i] != "minecraft:air") {
+						ingredients[input_names[i]] = input[i]
+					}
+				}
+				
+				event.custom({
+					type: "appliedenergistics2:inscriber",
+					mode: keep ? "inscribe" : "press",
+
+					ingredients: ingredients,
+					result: Ingredient.of(output)
+				})
+			}
+		},
+		
 		powah: {
 			energizing: (event, input, output, energy) => {
 				input = arrConvert(input).slice(0, 6)

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -197,6 +197,45 @@ onEvent("loaded", e => {
 				})
 			}
 		},
+		
+		atum: {
+			kiln: (event, input, output, experience) => {
+				if (typeof experience!="number") experience = 0.1
+
+				event.custom({
+					type: "atum:kiln",
+					
+					ingredient: Ingredient.of(input),
+					result: Ingredient.of(output),
+					
+					experience: experience
+				})
+			},
+			quern: (event, input, output, rotations) => {
+				if (typeof rotations!="number") rotations = 1
+
+				event.custom({
+					type: "atum:quern",
+
+					ingredient: Ingredient.of(input),
+					result: Ingredient.of(output),
+
+					rotations: rotations
+				})
+			},
+			spinning_wheel: (event, input, output, rotations) => {
+				if (typeof rotations!="number") rotations = 1
+
+				event.custom({
+					type: "atum:spinning_wheel",
+
+					ingredient: Ingredient.of(input),
+					result: Ingredient.of(output),
+
+					rotations: rotations
+				})
+			}
+		},
 
 		boss_tools: {
 			blasting: (event, input, output, cookTime) => {

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -7,20 +7,23 @@ function ingredientsConvert(i) {
 	i.forEach(item => {ingredients.push(Ingredient.of(item))})
 	return ingredients
 }
-function blockIngredientsConvert(i) {
-	let ingredients = []
-	i.forEach(block => {
-		if (block.substring(0, 1) == "#") {
-			ingredients.push({tag: block.substring(1)})
-		} else {
-			ingredients.push({block: block})
-		}
-	})
-	return ingredients
-}
 function fluidConvert(i) {
 	if (typeof i == "string") i = Fluid.of(i, 1000)
 	return i
+}
+function blockConvert(i) {
+	i.substring(0, 1)==="#" ? i = {tag: i.substring(1)} : i = {block: i}
+	return i
+}
+function blockConvertWithType(i) {
+	let block = blockConvert(i)
+	i.substring(0, 1)==="#" ? block["type"] = "tag" : block["type"] = "block"
+	return block
+}
+function blockIngredientsConvert(i) {
+	let ingredients = []
+	i.forEach(block => {ingredients.push(blockConvert(block))})
+	return ingredients
 }
 
 let i
@@ -143,6 +146,78 @@ onEvent("loaded", e => {
 					},
 					
 					weight: weight
+				})
+			}
+		},
+		
+		botania: {
+			brew: (event, input, outputBrew) => {
+				event.custom({
+					type: "botania:brew",
+
+					brew: outputBrew,
+					ingredients: ingredientsConvert(arrConvert(input))
+				})
+			},
+			elven_trade: (event, input, output) => {
+				event.custom({
+					type: "botania:elven_trade",
+
+					ingredients: ingredientsConvert(arrConvert(input)),
+					output: ingredientsConvert(arrConvert(output))
+				})
+			},
+			mana_infusion: (event, input, output, mana, catalyst) => {
+				if (mana==null) mana = 1000
+
+				event.custom({
+					type: "botania:mana_infusion",
+
+					input: Ingredient.of(input),
+					output: Ingredient.of(output),
+
+					mana: mana,
+					catalyst: catalyst==null ? null : blockConvertWithType(catalyst)
+				})
+			},
+			petal_apothecary: (event, input, output) => {
+				event.custom({
+					type: "botania:petal_apothecary",
+					
+					ingredients: ingredientsConvert(arrConvert(input)),
+					output: Ingredient.of(output)
+				})
+			},
+			pure_daisy: (event, input, output) => {
+				event.custom({
+					type: "botania:pure_daisy",
+
+					input: blockConvertWithType(input),
+					output: {name: output}
+				})
+			},
+			runic_altar: (event, input, output, mana) => {
+				if (mana==null) mana = 5000
+
+				event.custom({
+					type: "botania:runic_altar",
+
+					ingredients: ingredientsConvert(arrConvert(input)),
+					output: Ingredient.of(output),
+
+					mana: mana
+				})
+			},
+			terra_plate: (event, input, output, mana) => {
+				if (mana==null) mana = 100000
+
+				event.custom({
+					type: "botania:terra_plate",
+
+					ingredients: ingredientsConvert(arrConvert(input)),
+					result: Ingredient.of(output),
+
+					mana: mana
 				})
 			}
 		},

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -2,6 +2,9 @@ function arrConvert(i) {
 	if (!Array.isArray(i)) i = [i]
 	return i
 }
+function ingredientOfOnlyId(i) {
+	return i.substring(0, 1)==="#" ? {tag: Ingredient.of(i).id} : {item: Ingredient.of(i).id}
+}
 function ingredientsConvert(i) {
 	let ingredients = []
 	i.forEach(item => {ingredients.push(Ingredient.of(item))})
@@ -98,7 +101,7 @@ onEvent("loaded", e => {
 				})
 			}
 		},
-		
+
 		appliedenergistics2: {
 			grinder: (event, input, output, turns) => {
 				output = ingredientsConvert(arrConvert(output).slice(0, 3))
@@ -132,6 +135,47 @@ onEvent("loaded", e => {
 
 					ingredients: ingredients,
 					result: Ingredient.of(output)
+				})
+			}
+		},
+
+		ars_nouveau: {
+			enchanting_apparatus: (event, mainInput, sideInput, output) => {
+				let recipe = {
+					type: "ars_nouveau:enchanting_apparatus",
+
+					reagent: [ingredientOfOnlyId(mainInput)],
+					output: Ingredient.of(output)
+				}
+
+				sideInput = arrConvert(sideInput)
+				for (i = 0; i < sideInput.length; i++) {
+					if (Ingredient.of(sideInput[i]).id!=="minecraft:air") {
+						recipe[`item_${i + 1}`] = [ingredientOfOnlyId(sideInput[i])]
+					}
+				}
+
+				event.custom(recipe)
+			},
+			crush: (event, input, output) => {
+
+				event.custom({
+					type: "ars_nouveau:crush",
+					
+					input: Ingredient.of(input),
+					output: ingredientsConvert(arrConvert(output))
+				})
+			},
+			glyph_recipe: (event, input, output, tier) => {
+				if (typeof tier!="number" && typeof tier!="string") tier = 1
+				tier = ["ONE", "TWO", "THREE"][tier - 1]
+
+				event.custom({
+					type: "ars_nouveau:glyph_recipe",
+					
+					input: Ingredient.of(input).id,
+					output: Ingredient.of(output).id,
+					tier: tier===undefined ? "ONE" : tier
 				})
 			}
 		},

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -425,6 +425,104 @@ onEvent("loaded", e => {
 				})
 			}
 		},
+
+		industrialforegoing: {
+			dissolution_chamber: (event, input, inputFluid, output, outputFluid, time) => {
+				input = arrConvert(input).slice(0, 8)
+				inputFluid = fluidConvert(inputFluid)
+				outputFluid = fluidConvert(outputFluid)
+				if (time==null) time = 20
+
+				event.custom({
+					type: "industrialforegoing:dissolution_chamber",
+
+					input: ingredientsConvert(input),
+					inputFluid: `{FluidName:"${inputFluid.id}",Amount:${inputFluid.getAmount()}}`,
+
+					processingTime: time,
+
+					output: Ingredient.of(output),
+					outputFluid: `{FluidName:"${outputFluid!=null ? outputFluid.id : ""}",Amount:${outputFluid!=null ? outputFluid.getAmount() : 0}}`
+				})
+			},
+			fluid_extractor: (event, input, output, breakchance, result) => {
+				output = fluidConvert(output)
+				if (breakchance==null) breakchance = 0
+				if (result==null) result = "minecraft:air"
+
+				event.custom({
+					type: "industrialforegoing:fluid_extractor",
+
+					input: Ingredient.of(input),
+					result: result,
+					output: `{FluidName:"${output.id}",Amount:${output.getAmount()}}`,
+
+					breakChance: breakchance,
+					defaultRecipe: false
+				})
+			},
+			laser_drill: (event, output, catalyst, rarities, fluidRecipe, entity) => {
+				fluidRecipe ? output = fluidConvert(output) : output = Ingredient.of(output)
+				if (fluidRecipe!==true) fluidRecipe = false
+				if (typeof entity!=="string") entity = "minecraft:empty"
+				
+				let mineIn = []
+				if (typeof rarities[0]==='undefined') rarities = [["", "", ""]]
+				rarities.forEach(rarity => {
+					if (!(Array.isArray(rarity[0]))) rarity[0] = []
+					if (!(Array.isArray(rarity[1]))) rarity[1] = []
+					
+					if (!(Array.isArray(rarity[0][0]))) rarity[0][0] = []
+					if (typeof rarity[0][2]!=="string") rarity[0][2] = "minecraft:worldgen/biome"
+					let typeList = rarity[0][1] !== true
+					
+					if (typeof rarity[1][0]!=="number") rarity[1][0] = 0
+					if (typeof rarity[1][1]!=="number") rarity[1][1] = 64
+					if (typeof rarity[2]!=="number") rarity[2] = 1
+					
+					let whitelist = {}
+					let blacklist = {}
+					if (typeList) whitelist = {type: rarity[0][1], values: arrConvert(rarity[0][0])}
+					if (!(typeList)) blacklist = {type: rarity[0][1], values: arrConvert(rarity[0][0])}
+					
+					mineIn.push({
+						whitelist: whitelist,
+						blacklist: blacklist,
+						depth_min: rarity[1][0],
+						depth_max: rarity[1][1],
+						weight: rarity[2]
+					})
+				})
+
+				let recipe = {
+					type: fluidRecipe ? "industrialforegoing:laser_drill_fluid" : "industrialforegoing:laser_drill_ore",
+
+					output: fluidRecipe ? `{FluidName:"${output.id}",Amount:${output.getAmount()}}` : output,
+
+					pointer: 0,
+					catalyst: Ingredient.of(catalyst),
+
+					rarity: mineIn
+				}
+				if (fluidRecipe) recipe["entity"] = entity
+				
+				event.custom(recipe)
+			},
+			stonework_generate: (event, output, water, lava) => {
+				water = arrConvert(water)
+				lava = arrConvert(lava)
+				event.custom({
+					type: "industrialforegoing:stonework_generate",
+
+					output: Ingredient.of(output),
+
+					waterNeed: typeof water[0]!=="number" ? 1000 : water[0],
+					waterConsume: typeof water[1]!=="number" ? 0 : water[1],
+					lavaNeed: typeof lava[0]!=="number" ? 1000 : lava[0],
+					lavaConsume: typeof lava[1]!=="number" ? 0 : lava[1]
+				})
+			}
+		},
 		
 		powah: {
 			energizing: (event, input, output, energy) => {
@@ -438,43 +536,6 @@ onEvent("loaded", e => {
 					result: Ingredient.of(output),
 
 					energy: energy
-				})
-			}
-		},
-
-		industrialforegoing: {
-			dissolution_chamber: (event, input, inputFluid, output, outputFluid, time) => {
-				input = arrConvert(input).slice(0, 8)
-				inputFluid = fluidConvert(inputFluid)
-				outputFluid = fluidConvert(outputFluid)
-				if (time==null) time = 20
-
-				event.custom({
-					type: "industrialforegoing:dissolution_chamber",
-					
-					input: ingredientsConvert(input),
-					inputFluid: `{FluidName:"${inputFluid.id}",Amount:${inputFluid.getAmount()}}`,
-					
-					processingTime: time,
-		
-					output: Ingredient.of(output),
-					outputFluid: `{FluidName:"${outputFluid!=null ? outputFluid.id : ""}",Amount:${outputFluid!=null ? outputFluid.getAmount() : 0}}`
-				})
-			},
-			fluid_extractor: (event, input, output, breakchance, result) => {
-				output = fluidConvert(output)
-				if (breakchance==null) breakchance = 0
-				if (result==null) result = "minecraft:air"
-
-				event.custom({
-					type: "industrialforegoing:fluid_extractor",
-		
-					input: Ingredient.of(input),
-					result: result,
-					output: `{FluidName:"${output.id}",Amount:${output.getAmount()}}`,
-					
-					breakChance: breakchance,
-					defaultRecipe: false
 				})
 			}
 		}

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -49,7 +49,7 @@ onEvent("loaded", e => {
 				let input_names = ["top", "middle", "bottom"]
 				let ingredients = {}
 				for (i = 0; i < input.length; i++) {
-					if (input[i] != "" && input[i] != "minecraft:air") {
+					if (input[i] !== "" && input[i] !== "minecraft:air") {
 						ingredients[input_names[i]] = input[i]
 					}
 				}
@@ -66,13 +66,12 @@ onEvent("loaded", e => {
 
 		astralsorcery: {
 			block_transmutation: (event, input, output, starlight) => {
-				input = arrConvert(input)
 				if (starlight==null) starlight = 200
 
 				event.custom({
 					type: "astralsorcery:block_transmutation",
 
-					input: blockIngredientsConvert(input),
+					input: blockIngredientsConvert(arrConvert(input)),
 					output: {block: output},
 
 					starlight: starlight

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -11,6 +11,17 @@ function fluidConvert(i) {
 	if (typeof i == "string") i = Fluid.of(i, 1000)
 	return i
 }
+function fluidsConvert(i) {
+	let fluids = []
+	i.forEach(fluid => {fluids.push(fluidConvert(fluid).toJson())})
+	return fluids
+}
+function fluidConvertWithTag(i, amount) {
+	let fluid
+	i.substring(0, 1)==="#" ? fluid = {tag: i.substring(1)} : fluid = {fluid: i}
+	fluid["amount"] = amount
+	return fluid
+}
 function blockConvert(i, withType) {
 	let block
 	i.substring(0, 1)==="#" ? block = {tag: i.substring(1)} : block = {block: i}
@@ -52,7 +63,7 @@ onEvent("loaded", e => {
 				output = ingredientsConvert(arrConvert(output).slice(0, 3))
 				if (turns==null) turns = 4
 				console.log(Ingredient.of(input))
-				
+
 				event.custom({
 					type: "appliedenergistics2:grinder",
 
@@ -105,14 +116,14 @@ onEvent("loaded", e => {
 				settings = settings.slice(0, 3)
 				settings = settings.concat([false, true, false].slice(settings.length, 3))
 				if (inputFluid==null) inputFluid = "astralsorcery:liquid_starlight"
-				
+
 				event.custom({
-  					type: "astralsorcery:infuser",
-					
+					type: "astralsorcery:infuser",
+
 					fluidInput: inputFluid,
 					input: Ingredient.of(input),
 					output: Ingredient.of(output),
-					
+
 					consumptionChance: consumptionChance,
 					duration: duration,
 					consumeMultipleFluids: settings[0],
@@ -127,10 +138,10 @@ onEvent("loaded", e => {
 
 				event.custom({
 					type: "astralsorcery:lightwell",
-					
+
 					input: Ingredient.of(input),
 					output: outputFluid,
-					
+
 					productionMultiplier: productionMultiplier,
 					shatterMultiplier: shatterMultiplier,
 					color: color
@@ -147,22 +158,22 @@ onEvent("loaded", e => {
 
 				event.custom({
 					type: "astralsorcery:liquid_interaction",
-					
+
 					reactant1: fluid1.id,
 					reactant1Amount: fluid1.getAmount(),
 					chanceConsumeReactant1: inputFluid1[1],
-					
+
 					reactant2: fluid2.id,
 					reactant2Amount: fluid2.getAmount(),
 					chanceConsumeReactant2: inputFluid2[1],
-					
+
 					result: {
 						id: "astralsorcery:drop_item",
 						data: {
 							output: Ingredient.of(output)
 						}
 					},
-					
+
 					weight: weight
 				})
 			}
@@ -194,7 +205,7 @@ onEvent("loaded", e => {
 				})
 			}
 		},
-		
+
 		botania: {
 			brew: (event, input, outputBrew) => {
 				event.custom({
@@ -228,7 +239,7 @@ onEvent("loaded", e => {
 			petal_apothecary: (event, input, output) => {
 				event.custom({
 					type: "botania:petal_apothecary",
-					
+
 					ingredients: ingredientsConvert(arrConvert(input)),
 					output: Ingredient.of(output)
 				})
@@ -255,7 +266,7 @@ onEvent("loaded", e => {
 			},
 			terra_plate: (event, input, output, mana) => {
 				if (mana==null) mana = 100000
-				
+
 				event.custom({
 					type: "botania:terra_plate",
 
@@ -266,7 +277,7 @@ onEvent("loaded", e => {
 				})
 			}
 		},
-		
+
 		botanypots: {
 			crop: (event, inputSeed, SoilCategories, output, growthTicks, displayBlock) => {
 				if (growthTicks==null) growthTicks = 1200
@@ -282,14 +293,14 @@ onEvent("loaded", e => {
 				})
 
 				event.custom({
-				   	type: "botanypots:crop",
-					
+					type: "botanypots:crop",
+
 					seed: Ingredient.of(inputSeed).id,
 					results: results,
-					
-				    categories: arrConvert(SoilCategories),
-				   	growthTicks: growthTicks,
-				   	display: blockConvert(displayBlock, false)
+
+					categories: arrConvert(SoilCategories),
+					growthTicks: growthTicks,
+					display: blockConvert(displayBlock, false)
 				})
 			},
 			fertilizer: (event, fertilizer, minTicks, maxTicks) => {
@@ -298,7 +309,7 @@ onEvent("loaded", e => {
 
 				event.custom({
 					type: "botanypots:fertilizer",
-					
+
 					fertilizer: Ingredient.of(fertilizer),
 					minTicks: minTicks,
 					maxTicks: maxTicks
@@ -310,26 +321,26 @@ onEvent("loaded", e => {
 
 				event.custom({
 					type: "botanypots:soil",
-					
+
 					input: Ingredient.of(inputSoil),
-					
+
 					categories: arrConvert(SoilCategories),
 					growthModifier: growthModifier,
 					display: blockConvert(displayBlock, false)
 				})
 			}
 		},
-		
+
 		elementalcraft: {
 			binding: (event, input, output, elementType, elementAmount) => {
 				if (elementAmount==null) elementAmount = 1000
 
 				event.custom({
 					type: "elementalcraft:binding",
-					
+
 					ingredients: ingredientsConvert(arrConvert(input)),
 					output: Ingredient.of(output),
-					
+
 					element_type: elementType,
 					element_amount: elementAmount
 				})
@@ -346,17 +357,17 @@ onEvent("loaded", e => {
 						quality: typeof result[2]==='undefined' ? null : result[2]
 					})
 				})
-				
+
 				event.custom({
 					type: "elementalcraft:crystallization",
-					
+
 					ingredients: {
 						gem: input[0],
 						crystal: input[1],
 						shard: input[2]
 					},
 					outputs: results,
-					
+
 					element_type: elementType,
 					element_amount: elementAmount
 				})
@@ -366,10 +377,10 @@ onEvent("loaded", e => {
 
 				event.custom({
 					type: "elementalcraft:grinding",
-					
+
 					input: Ingredient.of(input),
 					output: Ingredient.of(output),
-					
+
 					element_amount: elementAmount,
 				})
 			},
@@ -378,9 +389,9 @@ onEvent("loaded", e => {
 
 				event.custom({
 					type: "elementalcraft:tool_infusion",
-					
+
 					input: Ingredient.of(input),
-					
+
 					tool_infusion: toolInfusionType,
 					element_amount: elementAmount,
 				})
@@ -407,11 +418,11 @@ onEvent("loaded", e => {
 
 				event.custom({
 					type: "elementalcraft:inscription",
-					
+
 					slate: input[0],
 					ingredients: input.slice(1),
 					output: outputItem,
-					
+
 					element_type: elementType,
 					element_amount: elementAmount
 				})
@@ -435,10 +446,10 @@ onEvent("loaded", e => {
 				let outputItem = Ingredient.of(output[0])
 				if (typeof output[1]!=='undefined') outputItem["nbt"] = output[1]
 
-				
+
 				event.custom({
 					type: "elementalcraft:spell_craft",
-					
+
 					gem: input[0],
 					crystal: input[1],
 					output: outputItem,
@@ -452,7 +463,7 @@ onEvent("loaded", e => {
 
 				event.custom({
 					type: "ftbic:antimatter_boost",
-					
+
 					ingredient: Ingredient.of(input),
 					boost: boost
 				})
@@ -462,7 +473,7 @@ onEvent("loaded", e => {
 
 				event.custom({
 					type: "ftbic:basic_generator_fuel",
-					
+
 					ingredient: Ingredient.of(input),
 					ticks: ticks
 				})
@@ -532,26 +543,26 @@ onEvent("loaded", e => {
 				fluidRecipe ? output = fluidConvert(output) : output = Ingredient.of(output)
 				if (fluidRecipe!==true) fluidRecipe = false
 				if (typeof entity!=="string") entity = "minecraft:empty"
-				
+
 				let mineIn = []
 				if (typeof rarities[0]==='undefined') rarities = [["", "", ""]]
 				rarities.forEach(rarity => {
 					if (!(Array.isArray(rarity[0]))) rarity[0] = []
 					if (!(Array.isArray(rarity[1]))) rarity[1] = []
-					
+
 					if (!(Array.isArray(rarity[0][0]))) rarity[0][0] = []
 					if (typeof rarity[0][2]!=="string") rarity[0][2] = "minecraft:worldgen/biome"
 					let typeList = rarity[0][1] !== true
-					
+
 					if (typeof rarity[1][0]!=="number") rarity[1][0] = 0
 					if (typeof rarity[1][1]!=="number") rarity[1][1] = 64
 					if (typeof rarity[2]!=="number") rarity[2] = 1
-					
+
 					let whitelist = {}
 					let blacklist = {}
 					if (typeList) whitelist = {type: rarity[0][1], values: arrConvert(rarity[0][0])}
 					if (!(typeList)) blacklist = {type: rarity[0][1], values: arrConvert(rarity[0][0])}
-					
+
 					mineIn.push({
 						whitelist: whitelist,
 						blacklist: blacklist,
@@ -572,7 +583,7 @@ onEvent("loaded", e => {
 					rarity: mineIn
 				}
 				if (fluidRecipe) recipe["entity"] = entity
-				
+
 				event.custom(recipe)
 			},
 			stonework_generate: (event, output, water, lava) => {
@@ -588,6 +599,222 @@ onEvent("loaded", e => {
 					lavaNeed: typeof lava[0]!=="number" ? 1000 : lava[0],
 					lavaConsume: typeof lava[1]!=="number" ? 0 : lava[1]
 				})
+			}
+		},
+
+		pneumaticcraft: {
+			amadron: (event, input, output) => {
+				input = arrConvert(input)
+				output = arrConvert(output)
+				let inputFluid = input[1] !== true
+				let outputFluid = output[1] !== true
+
+				event.custom({
+					type: "pneumaticcraft:amadron",
+
+					input: {
+						type: inputFluid ? "ITEM" : "FLUID",
+						id: inputFluid ? Ingredient.of(input[0]).id : fluidConvert(input[0]).id,
+						amount: inputFluid ? Ingredient.of(input[0]).getCount() : fluidConvert(input[0]).getAmount()
+					},
+					output: {
+						type: outputFluid ? "ITEM" : "FLUID",
+						id: outputFluid ? Ingredient.of(output[0]).id : fluidConvert(output[0]).id,
+						amount: outputFluid ? Ingredient.of(output[0]).getCount() : fluidConvert(output[0]).getAmount()
+					},
+
+					static: true,
+					level: 0
+				})
+			},
+			assembly_laser: (event, input, output, isDrill) => {
+				let recipe = {
+					type: "pneumaticcraft:assembly_laser",
+
+					input: {
+						item: Ingredient.of(input).id,
+						count: Ingredient.of(input).getCount()
+					},
+					result: Ingredient.of(output),
+
+					program: isDrill!==true ? "laser" : "drill"
+				}
+
+				if (Ingredient.of(input).getCount()!==1) recipe["input"]["type"] = "pneumaticcraft:stacked_item"
+
+				event.custom(recipe)
+			},
+			explosion_crafting: (event, input, output, loss_rate) => {
+				if (typeof loss_rate!=="number") loss_rate = 20
+
+				event.custom({
+					type: "pneumaticcraft:explosion_crafting",
+
+					input: Ingredient.of(input),
+					results: ingredientsConvert(arrConvert(output)),
+
+					loss_rate: loss_rate
+				})
+			},
+			heat_frame_cooling: (event, input, output, max_temp, bonusOutput) => {
+				input = arrConvert(input)
+				if (typeof input[1]!=="number") input[1] = 1000
+				if (typeof max_temp!=="number") max_temp = 273
+				if (bonusOutput==null) bonusOutput = []
+				if (typeof bonusOutput[0]!=="number") bonusOutput[0] = 0
+				if (typeof bonusOutput[1]!=="number") bonusOutput[1] = 0
+
+				event.custom({
+					type: "pneumaticcraft:heat_frame_cooling",
+
+					input: Object.assign(fluidConvertWithTag(input[0], input[1]), {type: "pneumaticcraft:fluid"}),
+					result: Ingredient.of(output),
+
+					max_temp: max_temp,
+					bonus_output: {
+						multiplier: bonusOutput[0],
+						limit: bonusOutput[1]
+					}
+				})
+			},
+			heat_properties: (event, input, output, temperature, thermalResistance, heatCapacity) => {
+				output = arrConvert(output)
+				if (typeof temperature!=="number") temperature = 298
+				if (typeof thermalResistance!=="number") thermalResistance = 200
+				if (typeof heatCapacity!=="number") heatCapacity = 5000
+
+				let recipe = {
+					type: "pneumaticcraft:heat_properties",
+					block: input,
+					temperature: temperature,
+					thermalResistance: thermalResistance,
+					heatCapacity: heatCapacity,
+				}
+
+				if (output[0]!=="" && output[0]!=="minecraft:air") recipe["transformCold"] = {block: output[0]}
+				if (output[1]!=="" && output[1]!=="minecraft:air") recipe["transformHot"] = {block: output[1]}
+
+				event.custom(recipe)
+			},
+			fluid_mixer: (event, input1, input2, outputFluid, outputItem, pressure, time) => {
+				outputFluid = fluidConvert(outputFluid)
+				outputItem = Ingredient.of(outputItem)
+				input1 = arrConvert(input1)
+				input2 = arrConvert(input2)
+				if (typeof input1[1]!=="number") input1[1] = 1000
+				if (typeof input2[1]!=="number") input2[1] = 1000
+				if (typeof time!=="number") time = 200
+				if (typeof pressure!=="number") pressure = 1
+				
+				recipe = {
+					type: "pneumaticcraft:fluid_mixer",
+
+					input1: Object.assign(fluidConvertWithTag(input1[0], input1[1]), {type: "pneumaticcraft:fluid"}),
+					input2: Object.assign(fluidConvertWithTag(input2[0], input2[1]), {type: "pneumaticcraft:fluid"}),
+
+					pressure: pressure,
+					time: time
+				}
+				
+				if (outputFluid!=null && outputFluid.id!=="minecraft:empty") recipe["fluid_output"] = outputFluid
+				if (outputItem!=null && outputItem.id!=="minecraft:air") recipe["item_output"] = outputItem
+				
+				console.log(recipe)
+				
+				event.custom(recipe)
+			},
+			fuel_quality: (event, input, air_per_bucket, burn_rate) => {
+				input = arrConvert(input)
+				if (typeof input[1]!=="number") input[1] = 1000
+				if (typeof air_per_bucket!=="number") air_per_bucket = 100000
+				if (typeof burn_rate!=="number") burn_rate = 1
+
+				event.custom({
+					type: "pneumaticcraft:fuel_quality",
+					
+					fluid: Object.assign(fluidConvertWithTag(input[0], input[1]), {type: "pneumaticcraft:fluid"}),
+					
+					air_per_bucket: air_per_bucket,
+					burn_rate: burn_rate
+				})
+			},
+			pressure_chamber: (event, input, output, pressure) => {
+				if (typeof pressure!=="number") pressure = 1
+
+				input = ingredientsConvert(arrConvert(input))
+				input.forEach(item => {
+					let itemJson = {
+						item: item.id,
+						count: item.getCount()
+					}
+					if (item.getCount()!==1) itemJson["type"] = "pneumaticcraft:stacked_item"
+					input[input.indexOf(item)] = itemJson
+				})
+				
+				event.custom({
+					type: "pneumaticcraft:pressure_chamber",
+					
+					inputs: input,
+					results: ingredientsConvert(arrConvert(output)),
+					
+					pressure: pressure
+				})
+			},
+			refinery: (event, input, output, temperature) => {
+				console.log(fluidsConvert(arrConvert(output)))
+				input = arrConvert(input)
+				if (typeof input[1]!=="number") input[1] = 1000
+
+				let temperatures = {}
+				if (typeof temperature[0]==="number") temperatures["min_temp"] = temperature[0]
+				if (typeof temperature[1]==="number") temperatures["max_temp"] = temperature[1]
+				
+				event.custom({
+					type: "pneumaticcraft:refinery",
+					
+					input: Object.assign(fluidConvertWithTag(input[0], input[1]), {type: "pneumaticcraft:fluid"}),
+					results: fluidsConvert(arrConvert(output).slice(0, 4)),
+					
+					temperature: temperatures,
+				})
+			},
+			thermo_plant: (event, inputItem, inputFluid, outputItem, outputFluid, temperature, pressure, speed, exothermic) => {
+				inputItem = Ingredient.of(inputItem)
+				let itemJson = {item: inputItem.id, count: inputItem.getCount()}
+				if (inputItem.getCount()!==1) inputItem = Object.assign(itemJson, {type: "pneumaticcraft:stacked_item"})
+				
+				inputFluid = arrConvert(inputFluid)
+				if (typeof inputFluid[1]!=="number") inputFluid[1] = 1000
+				let inputFluidConverted = inputFluid[0].substring(0, 1)==="#" ?  fluidConvert("minecraft:water") : fluidConvert(inputFluid[0], inputFluid[1])
+				
+				outputItem = Ingredient.of(outputItem)
+				outputFluid = fluidConvert(outputFluid)
+				
+				if (typeof speed!=="number") speed = 1
+				temperature = arrConvert(temperature)
+				
+				let recipe = {
+					type: "pneumaticcraft:thermo_plant",
+					speed: speed,
+					exothermic: exothermic===true
+				}
+				
+				if (inputItem!=null && inputItem.id!=="minecraft:air") recipe["item_input"] = inputItem
+				if (inputFluid!=null && inputFluidConverted.id!=="minecraft:empty") {
+					recipe["fluid_input"] = Object.assign(fluidConvertWithTag(inputFluid[0], inputFluid[1]), {type: "pneumaticcraft:fluid"})
+				}
+				
+				if (outputItem!=null && outputItem.id!=="minecraft:air") recipe["item_output"] = outputItem
+				if (outputFluid!=null && outputFluid.id!=="minecraft:empty") recipe["fluid_output"] = outputFluid
+				
+				let temperatures = {}
+				if (typeof temperature[0]==="number") temperatures["min_temp"] = temperature[0]
+				if (typeof temperature[1]==="number") temperatures["max_temp"] = temperature[1]
+				if (temperatures!=={} || temperature===[]) recipe["temperature"] = temperatures
+				
+				if (typeof pressure==="number") recipe["pressure"] = pressure
+				
+				event.custom(recipe)
 			}
 		},
 		

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -520,7 +520,6 @@ onEvent("loaded", e => {
 					}
 				}
 				
-				
 				event.custom({
 					type: "draconicevolution:fusion_crafting",
 
@@ -530,6 +529,34 @@ onEvent("loaded", e => {
 
 					total_energy: energy,
 					tier: tier
+				})
+			}
+		},
+		
+		divinerpg: {
+			arcanium_extractor: (event, input,  output, experience, time) => {
+				if (typeof experience!="number") experience = 0.1
+				if (typeof time!="number") time = 200
+
+				event.custom({
+					type: "divinerpg:arcanium_extractor",
+					
+					ingredient: Ingredient.of(input),
+					result: Ingredient.of(output),
+					
+					experience: 0.1,
+					cookingtime: 100
+				})
+			},
+			
+			infusion_table: (event, input, template, output) => {
+
+				event.custom({
+					type: "divinerpg:infusion_table",
+					
+					input: Ingredient.of(input),
+					template: Ingredient.of(template),
+					output: Ingredient.of(output)
 				})
 			}
 		},

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -84,7 +84,7 @@ function SMIngredientConvert(i) {
 let i
 
 onEvent("loaded", e => {
-	global.more_recipe_types = {
+	global.mrt = {
 		aoa3: {
 			infusion: (event, mainInput, input, output, id) => {
 				event.custom({

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -61,7 +61,7 @@ onEvent("loaded", e => {
 		appliedenergistics2: {
 			grinder: (event, input, output, turns) => {
 				output = ingredientsConvert(arrConvert(output).slice(0, 3))
-				if (turns==null) turns = 4
+				if (typeof turns!="number") turns = 4
 				console.log(Ingredient.of(input))
 
 				event.custom({
@@ -88,7 +88,7 @@ onEvent("loaded", e => {
 
 				event.custom({
 					type: "appliedenergistics2:inscriber",
-					mode: keep ? "inscribe" : "press",
+					mode: keep===true ? "inscribe" : "press",
 
 					ingredients: ingredients,
 					result: Ingredient.of(output)
@@ -98,7 +98,7 @@ onEvent("loaded", e => {
 
 		astralsorcery: {
 			block_transmutation: (event, input, output, starlight) => {
-				if (starlight==null) starlight = 200
+				if (typeof starlight!="number") starlight = 200
 
 				event.custom({
 					type: "astralsorcery:block_transmutation",
@@ -110,12 +110,12 @@ onEvent("loaded", e => {
 				})
 			},
 			infuser: (event, input, output, duration, consumptionChance, settings, inputFluid) => {
-				if (duration==null) duration = 100
-				if (consumptionChance==null) consumptionChance = 0.1
-				if (settings==null) settings = [false, true, false]
+				if (typeof duration!="number") duration = 100
+				if (typeof consumptionChance!="number") consumptionChance = 0.1
+				if (!Array.isArray(settings)) settings = [false, true, false]
 				settings = settings.slice(0, 3)
 				settings = settings.concat([false, true, false].slice(settings.length, 3))
-				if (inputFluid==null) inputFluid = "astralsorcery:liquid_starlight"
+				if (typeof inputFluid!="string") inputFluid = "astralsorcery:liquid_starlight"
 
 				event.custom({
 					type: "astralsorcery:infuser",
@@ -132,9 +132,9 @@ onEvent("loaded", e => {
 				})
 			},
 			lightwell: (event, input, outputFluid, productionMultiplier, shatterMultiplier, color) => {
-				if (productionMultiplier==null) productionMultiplier = 1
-				if (shatterMultiplier==null) shatterMultiplier = 10
-				if (color==null) color = -2236929
+				if (typeof productionMultiplier!="number") productionMultiplier = 1
+				if (typeof shatterMultiplier!="number") shatterMultiplier = 10
+				if (typeof color!="number") color = -2236929
 
 				event.custom({
 					type: "astralsorcery:lightwell",
@@ -152,9 +152,9 @@ onEvent("loaded", e => {
 				inputFluid2 = arrConvert(inputFluid2)
 				let fluid1 = fluidConvert(inputFluid1[0])
 				let fluid2 = fluidConvert(inputFluid2[0])
-				if (typeof inputFluid1[1]==='undefined') inputFluid1.push(1)
-				if (typeof inputFluid2[1]==='undefined') inputFluid2.push(1)
-				if (weight==null) weight = 1
+				if (typeof inputFluid1[1]=='undefined') inputFluid1.push(1)
+				if (typeof inputFluid2[1]=='undefined') inputFluid2.push(1)
+				if (typeof weight!="number") weight = 1
 
 				event.custom({
 					type: "astralsorcery:liquid_interaction",
@@ -181,7 +181,7 @@ onEvent("loaded", e => {
 
 		boss_tools: {
 			blasting: (event, input, output, cookTime) => {
-				if (cookTime==null) cookTime = 200
+				if (typeof cookTime!="number") cookTime = 200
 
 				event.custom({
 					type: "boss_tools:blasting",
@@ -193,7 +193,7 @@ onEvent("loaded", e => {
 				})
 			},
 			compressing: (event, input, output, cookTime) => {
-				if (cookTime==null) cookTime = 200
+				if (typeof cookTime!="number") cookTime = 200
 
 				event.custom({
 					type: "boss_tools:compressing",
@@ -224,7 +224,7 @@ onEvent("loaded", e => {
 				})
 			},
 			mana_infusion: (event, input, output, mana, catalyst) => {
-				if (mana==null) mana = 1000
+				if (typeof mana!="number") mana = 1000
 
 				event.custom({
 					type: "botania:mana_infusion",
@@ -233,7 +233,7 @@ onEvent("loaded", e => {
 					output: Ingredient.of(output),
 
 					mana: mana,
-					catalyst: catalyst==null ? null : blockConvert(catalyst, true)
+					catalyst: typeof catalyst!="string" ? null : blockConvert(catalyst, true)
 				})
 			},
 			petal_apothecary: (event, input, output) => {
@@ -253,7 +253,7 @@ onEvent("loaded", e => {
 				})
 			},
 			runic_altar: (event, input, output, mana) => {
-				if (mana==null) mana = 5000
+				if (typeof mana!="number") mana = 5000
 
 				event.custom({
 					type: "botania:runic_altar",
@@ -265,7 +265,7 @@ onEvent("loaded", e => {
 				})
 			},
 			terra_plate: (event, input, output, mana) => {
-				if (mana==null) mana = 100000
+				if (typeof mana!="number") mana = 100000
 
 				event.custom({
 					type: "botania:terra_plate",
@@ -280,15 +280,15 @@ onEvent("loaded", e => {
 
 		botanypots: {
 			crop: (event, inputSeed, SoilCategories, output, growthTicks, displayBlock) => {
-				if (growthTicks==null) growthTicks = 1200
-				if (displayBlock==null) displayBlock = inputSeed
+				if (typeof growthTicks!="number") growthTicks = 1200
+				if (typeof displayBlock!="string") displayBlock = inputSeed
 				let results = []
 				output.forEach(roll => {
 					results.push({
 						output: Ingredient.of(roll[0]),
-						chance: typeof roll[1]==='undefined' ? 1 : roll[1],
-						minRolls: typeof roll[2]==='undefined' ? 1 : roll[2],
-						maxRolls: typeof roll[3]==='undefined' ? 1 : roll[3]
+						chance: typeof roll[1]=='undefined' ? 1 : roll[1],
+						minRolls: typeof roll[2]=='undefined' ? 1 : roll[2],
+						maxRolls: typeof roll[3]=='undefined' ? 1 : roll[3]
 					})
 				})
 
@@ -304,8 +304,8 @@ onEvent("loaded", e => {
 				})
 			},
 			fertilizer: (event, fertilizer, minTicks, maxTicks) => {
-				if (minTicks==null) minTicks = 100
-				if (maxTicks==null) maxTicks = minTicks + 100
+				if (typeof minTicks!="number") minTicks = 100
+				if (typeof maxTicks!="number") maxTicks = minTicks + 100
 
 				event.custom({
 					type: "botanypots:fertilizer",
@@ -316,8 +316,8 @@ onEvent("loaded", e => {
 				})
 			},
 			soil: (event, inputSoil, SoilCategories, growthModifier, displayBlock) => {
-				if (growthModifier==null) growthModifier = 0
-				if (displayBlock==null) displayBlock = inputSoil
+				if (typeof growthModifier!="number") growthModifier = 0
+				if (typeof displayBlock!="string") displayBlock = inputSoil
 
 				event.custom({
 					type: "botanypots:soil",
@@ -333,7 +333,7 @@ onEvent("loaded", e => {
 
 		elementalcraft: {
 			binding: (event, input, output, elementType, elementAmount) => {
-				if (elementAmount==null) elementAmount = 1000
+				if (typeof elementAmount!="number") elementAmount = 1000
 
 				event.custom({
 					type: "elementalcraft:binding",
@@ -347,14 +347,14 @@ onEvent("loaded", e => {
 			},
 			crystallization: (event, input, output, elementType, elementAmount) => {
 				input = ingredientsConvert(arrConvert(input))
-				if (elementAmount==null) elementAmount = 1000
+				if (typeof elementAmount!="number") elementAmount = 1000
 				let results = []
 				output.forEach(result => {
 					let resultItem = Ingredient.of(result[0])
 					results.push({
 						result: {id: resultItem.id, Count: resultItem.getCount()},
-						weight: typeof result[1]==='undefined' ? 1 : result[1],
-						quality: typeof result[2]==='undefined' ? null : result[2]
+						weight: typeof result[1]=='undefined' ? 1 : result[1],
+						quality: typeof result[2]=='undefined' ? null : result[2]
 					})
 				})
 
@@ -373,7 +373,7 @@ onEvent("loaded", e => {
 				})
 			},
 			grinding: (event, input, output, elementAmount) => {
-				if (elementAmount==null) elementAmount = 1000
+				if (typeof elementAmount!="number") elementAmount = 1000
 
 				event.custom({
 					type: "elementalcraft:grinding",
@@ -385,7 +385,7 @@ onEvent("loaded", e => {
 				})
 			},
 			tool_infusion: (event, input, toolInfusionType, elementAmount) => {
-				if (elementAmount==null) elementAmount = 1000
+				if (typeof elementAmount!="number") elementAmount = 1000
 
 				event.custom({
 					type: "elementalcraft:tool_infusion",
@@ -397,7 +397,7 @@ onEvent("loaded", e => {
 				})
 			},
 			infusion: (event, input, output, elementType, elementAmount) => {
-				if (elementAmount==null) elementAmount = 1000
+				if (typeof elementAmount!="number") elementAmount = 1000
 
 				event.custom({
 					type: "elementalcraft:infusion",
@@ -413,8 +413,8 @@ onEvent("loaded", e => {
 				input = ingredientsConvert(arrConvert(input).slice(0, 4))
 				output = arrConvert(output)
 				let outputItem = Ingredient.of(output[0])
-				if (typeof output[1]!=='undefined') outputItem["nbt"] = output[1]
-				if (elementAmount==null) elementAmount = 1000
+				if (typeof output[1]!='undefined') outputItem["nbt"] = output[1]
+				if (typeof elementAmount!="number") elementAmount = 1000
 
 				event.custom({
 					type: "elementalcraft:inscription",
@@ -429,7 +429,7 @@ onEvent("loaded", e => {
 			},
 			pureinfusion: (event, input, output, elementAmount) => {
 				input = arrConvert(input).slice(0, 5)
-				if (elementAmount==null) elementAmount = 1000
+				if (typeof elementAmount!="number") elementAmount = 1000
 
 				event.custom({
 					type: "elementalcraft:pureinfusion",
@@ -444,7 +444,7 @@ onEvent("loaded", e => {
 				input = ingredientsConvert(arrConvert(input))
 				output = arrConvert(output)
 				let outputItem = Ingredient.of(output[0])
-				if (typeof output[1]!=='undefined') outputItem["nbt"] = output[1]
+				if (typeof output[1]!='undefined') outputItem["nbt"] = output[1]
 
 
 				event.custom({
@@ -459,7 +459,7 @@ onEvent("loaded", e => {
 
 		ftbic: {
 			antimatter_boost: (event, input, boost) => {
-				if (typeof boost!=="number") boost = 1000
+				if (typeof boost!="number") boost = 1000
 
 				event.custom({
 					type: "ftbic:antimatter_boost",
@@ -469,7 +469,7 @@ onEvent("loaded", e => {
 				})
 			},
 			basic_generator_fuel: (event, input, ticks) => {
-				if (typeof ticks!=="number") ticks = 200
+				if (typeof ticks!="number") ticks = 200
 
 				event.custom({
 					type: "ftbic:basic_generator_fuel",
@@ -509,7 +509,7 @@ onEvent("loaded", e => {
 				input = arrConvert(input).slice(0, 8)
 				inputFluid = fluidConvert(inputFluid)
 				outputFluid = fluidConvert(outputFluid)
-				if (time==null) time = 20
+				if (typeof time!="number") time = 20
 
 				event.custom({
 					type: "industrialforegoing:dissolution_chamber",
@@ -525,8 +525,8 @@ onEvent("loaded", e => {
 			},
 			fluid_extractor: (event, input, output, breakchance, result) => {
 				output = fluidConvert(output)
-				if (breakchance==null) breakchance = 0
-				if (result==null) result = "minecraft:air"
+				if (typeof breakchance!="number") breakchance = 0
+				if (typeof result!="string") result = "minecraft:air"
 
 				event.custom({
 					type: "industrialforegoing:fluid_extractor",
@@ -542,21 +542,21 @@ onEvent("loaded", e => {
 			laser_drill: (event, output, catalyst, rarities, fluidRecipe, entity) => {
 				fluidRecipe ? output = fluidConvert(output) : output = Ingredient.of(output)
 				if (fluidRecipe!==true) fluidRecipe = false
-				if (typeof entity!=="string") entity = "minecraft:empty"
+				if (typeof entity!="string") entity = "minecraft:empty"
 
 				let mineIn = []
-				if (typeof rarities[0]==='undefined') rarities = [["", "", ""]]
+				if (typeof rarities[0]=='undefined') rarities = [["", "", ""]]
 				rarities.forEach(rarity => {
 					if (!(Array.isArray(rarity[0]))) rarity[0] = []
 					if (!(Array.isArray(rarity[1]))) rarity[1] = []
 
 					if (!(Array.isArray(rarity[0][0]))) rarity[0][0] = []
-					if (typeof rarity[0][2]!=="string") rarity[0][2] = "minecraft:worldgen/biome"
+					if (typeof rarity[0][2]!="string") rarity[0][2] = "minecraft:worldgen/biome"
 					let typeList = rarity[0][1] !== true
 
-					if (typeof rarity[1][0]!=="number") rarity[1][0] = 0
-					if (typeof rarity[1][1]!=="number") rarity[1][1] = 64
-					if (typeof rarity[2]!=="number") rarity[2] = 1
+					if (typeof rarity[1][0]!="number") rarity[1][0] = 0
+					if (typeof rarity[1][1]!="number") rarity[1][1] = 64
+					if (typeof rarity[2]!="number") rarity[2] = 1
 
 					let whitelist = {}
 					let blacklist = {}
@@ -594,10 +594,10 @@ onEvent("loaded", e => {
 
 					output: Ingredient.of(output),
 
-					waterNeed: typeof water[0]!=="number" ? 1000 : water[0],
-					waterConsume: typeof water[1]!=="number" ? 0 : water[1],
-					lavaNeed: typeof lava[0]!=="number" ? 1000 : lava[0],
-					lavaConsume: typeof lava[1]!=="number" ? 0 : lava[1]
+					waterNeed: typeof water[0]!="number" ? 1000 : water[0],
+					waterConsume: typeof water[1]!="number" ? 0 : water[1],
+					lavaNeed: typeof lava[0]!="number" ? 1000 : lava[0],
+					lavaConsume: typeof lava[1]!="number" ? 0 : lava[1]
 				})
 			}
 		},
@@ -637,7 +637,7 @@ onEvent("loaded", e => {
 					},
 					result: Ingredient.of(output),
 
-					program: isDrill!==true ? "laser" : "drill"
+					program: isDrill===true ? "drill" : "laser"
 				}
 
 				if (Ingredient.of(input).getCount()!==1) recipe["input"]["type"] = "pneumaticcraft:stacked_item"
@@ -645,7 +645,7 @@ onEvent("loaded", e => {
 				event.custom(recipe)
 			},
 			explosion_crafting: (event, input, output, loss_rate) => {
-				if (typeof loss_rate!=="number") loss_rate = 20
+				if (typeof loss_rate!="number") loss_rate = 20
 
 				event.custom({
 					type: "pneumaticcraft:explosion_crafting",
@@ -658,11 +658,11 @@ onEvent("loaded", e => {
 			},
 			heat_frame_cooling: (event, input, output, max_temp, bonusOutput) => {
 				input = arrConvert(input)
-				if (typeof input[1]!=="number") input[1] = 1000
-				if (typeof max_temp!=="number") max_temp = 273
-				if (bonusOutput==null) bonusOutput = []
-				if (typeof bonusOutput[0]!=="number") bonusOutput[0] = 0
-				if (typeof bonusOutput[1]!=="number") bonusOutput[1] = 0
+				if (typeof input[1]!="number") input[1] = 1000
+				if (typeof max_temp!="number") max_temp = 273
+				if (!Array.isArray(bonusOutput)) bonusOutput = []
+				if (typeof bonusOutput[0]!="number") bonusOutput[0] = 0
+				if (typeof bonusOutput[1]!="number") bonusOutput[1] = 0
 
 				event.custom({
 					type: "pneumaticcraft:heat_frame_cooling",
@@ -679,9 +679,9 @@ onEvent("loaded", e => {
 			},
 			heat_properties: (event, input, output, temperature, thermalResistance, heatCapacity) => {
 				output = arrConvert(output)
-				if (typeof temperature!=="number") temperature = 298
-				if (typeof thermalResistance!=="number") thermalResistance = 200
-				if (typeof heatCapacity!=="number") heatCapacity = 5000
+				if (typeof temperature!="number") temperature = 298
+				if (typeof thermalResistance!="number") thermalResistance = 200
+				if (typeof heatCapacity!="number") heatCapacity = 5000
 
 				let recipe = {
 					type: "pneumaticcraft:heat_properties",
@@ -701,10 +701,10 @@ onEvent("loaded", e => {
 				outputItem = Ingredient.of(outputItem)
 				input1 = arrConvert(input1)
 				input2 = arrConvert(input2)
-				if (typeof input1[1]!=="number") input1[1] = 1000
-				if (typeof input2[1]!=="number") input2[1] = 1000
-				if (typeof time!=="number") time = 200
-				if (typeof pressure!=="number") pressure = 1
+				if (typeof input1[1]!="number") input1[1] = 1000
+				if (typeof input2[1]!="number") input2[1] = 1000
+				if (typeof time!="number") time = 200
+				if (typeof pressure!="number") pressure = 1
 				
 				recipe = {
 					type: "pneumaticcraft:fluid_mixer",
@@ -725,9 +725,9 @@ onEvent("loaded", e => {
 			},
 			fuel_quality: (event, input, air_per_bucket, burn_rate) => {
 				input = arrConvert(input)
-				if (typeof input[1]!=="number") input[1] = 1000
-				if (typeof air_per_bucket!=="number") air_per_bucket = 100000
-				if (typeof burn_rate!=="number") burn_rate = 1
+				if (typeof input[1]!="number") input[1] = 1000
+				if (typeof air_per_bucket!="number") air_per_bucket = 100000
+				if (typeof burn_rate!="number") burn_rate = 1
 
 				event.custom({
 					type: "pneumaticcraft:fuel_quality",
@@ -739,7 +739,7 @@ onEvent("loaded", e => {
 				})
 			},
 			pressure_chamber: (event, input, output, pressure) => {
-				if (typeof pressure!=="number") pressure = 1
+				if (typeof pressure!="number") pressure = 1
 
 				input = ingredientsConvert(arrConvert(input))
 				input.forEach(item => {
@@ -763,11 +763,11 @@ onEvent("loaded", e => {
 			refinery: (event, input, output, temperature) => {
 				console.log(fluidsConvert(arrConvert(output)))
 				input = arrConvert(input)
-				if (typeof input[1]!=="number") input[1] = 1000
+				if (typeof input[1]!="number") input[1] = 1000
 
 				let temperatures = {}
-				if (typeof temperature[0]==="number") temperatures["min_temp"] = temperature[0]
-				if (typeof temperature[1]==="number") temperatures["max_temp"] = temperature[1]
+				if (typeof temperature[0]=="number") temperatures["min_temp"] = temperature[0]
+				if (typeof temperature[1]=="number") temperatures["max_temp"] = temperature[1]
 				
 				event.custom({
 					type: "pneumaticcraft:refinery",
@@ -784,13 +784,13 @@ onEvent("loaded", e => {
 				if (inputItem.getCount()!==1) inputItem = Object.assign(itemJson, {type: "pneumaticcraft:stacked_item"})
 				
 				inputFluid = arrConvert(inputFluid)
-				if (typeof inputFluid[1]!=="number") inputFluid[1] = 1000
+				if (typeof inputFluid[1]!="number") inputFluid[1] = 1000
 				let inputFluidConverted = inputFluid[0].substring(0, 1)==="#" ?  fluidConvert("minecraft:water") : fluidConvert(inputFluid[0], inputFluid[1])
 				
 				outputItem = Ingredient.of(outputItem)
 				outputFluid = fluidConvert(outputFluid)
 				
-				if (typeof speed!=="number") speed = 1
+				if (typeof speed!="number") speed = 1
 				temperature = arrConvert(temperature)
 				
 				let recipe = {
@@ -808,11 +808,11 @@ onEvent("loaded", e => {
 				if (outputFluid!=null && outputFluid.id!=="minecraft:empty") recipe["fluid_output"] = outputFluid
 				
 				let temperatures = {}
-				if (typeof temperature[0]==="number") temperatures["min_temp"] = temperature[0]
-				if (typeof temperature[1]==="number") temperatures["max_temp"] = temperature[1]
+				if (typeof temperature[0]=="number") temperatures["min_temp"] = temperature[0]
+				if (typeof temperature[1]=="number") temperatures["max_temp"] = temperature[1]
 				if (temperatures!=={} || temperature===[]) recipe["temperature"] = temperatures
 				
-				if (typeof pressure==="number") recipe["pressure"] = pressure
+				if (typeof pressure=="number") recipe["pressure"] = pressure
 				
 				event.custom(recipe)
 			}
@@ -821,7 +821,7 @@ onEvent("loaded", e => {
 		powah: {
 			energizing: (event, input, output, energy) => {
 				input = arrConvert(input).slice(0, 6)
-				if (energy==null) energy = 100
+				if (typeof energy!="number") energy = 100
 
 				event.custom({
 					type: "powah:energizing",

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -147,6 +147,33 @@ onEvent("loaded", e => {
 				})
 			}
 		},
+
+		boss_tools: {
+			blasting: (event, input, output, cookTime) => {
+				if (cookTime==null) cookTime = 200
+
+				event.custom({
+					type: "boss_tools:blasting",
+
+					input: {ingredient: Ingredient.of(input)},
+					output: Ingredient.of(output),
+
+					cookTime: cookTime
+				})
+			},
+			compressing: (event, input, output, cookTime) => {
+				if (cookTime==null) cookTime = 200
+
+				event.custom({
+					type: "boss_tools:compressing",
+
+					input: {ingredient: Ingredient.of(input)},
+					output: Ingredient.of(output),
+
+					cookTime: cookTime
+				})
+			}
+		},
 		
 		botania: {
 			brew: (event, input, outputBrew) => {

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -46,8 +46,8 @@ onEvent("loaded", e => {
 			},
 			inscriber: (event, input, output, keep) => {
 				input = ingredientsConvert(arrConvert(input).slice(0, 3))
-				input_names = ["top", "middle", "bottom"]
-				ingredients = {}
+				let input_names = ["top", "middle", "bottom"]
+				let ingredients = {}
 				for (i = 0; i < input.length; i++) {
 					if (input[i] != "" && input[i] != "minecraft:air") {
 						ingredients[input_names[i]] = input[i]
@@ -119,8 +119,8 @@ onEvent("loaded", e => {
 			liquid_interaction: (event, inputFluid1, inputFluid2, output, weight) => {
 				inputFluid1 = arrConvert(inputFluid1)
 				inputFluid2 = arrConvert(inputFluid2)
-				fluid1 = fluidConvert(inputFluid1[0])
-				fluid2 = fluidConvert(inputFluid2[0])
+				let fluid1 = fluidConvert(inputFluid1[0])
+				let fluid2 = fluidConvert(inputFluid2[0])
 				if (typeof inputFluid1[1]==='undefined') inputFluid1.push(1)
 				if (typeof inputFluid2[1]==='undefined') inputFluid2.push(1)
 				if (weight==null) weight = 1

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -777,6 +777,38 @@ onEvent("loaded", e => {
 				})
 			}
 		},
+		
+		mysticalagriculture: {
+			infusion: (event, mainInput, sideInput, output) => {
+				event.custom({
+					type: "mysticalagriculture:infusion",
+					
+					input: Ingredient.of(mainInput),
+					ingredients: ingredientsConvert(arrConvert(sideInput).slice(0, 8)),
+					result: Ingredient.of(output)
+				})
+			},
+			reprocessor: (event, input, output) => {
+				event.custom({
+					type: "mysticalagriculture:reprocessor",
+
+					input: Ingredient.of(input),
+					result: Ingredient.of(output)
+				})
+			},
+			soul_extraction: (event, input, soulType, soulAmount) => {
+				if (typeof soulAmount!="number") soulAmount = 1
+				
+				event.custom({
+					type: "mysticalagriculture:soul_extraction",
+					input: Ingredient.of(input),
+					output: {
+						type: soulType,
+						souls: soulAmount
+					}
+				})
+			}
+		},
 
 		pneumaticcraft: {
 			amadron: (event, input, output) => {

--- a/startup_scripts/moretypes.js
+++ b/startup_scripts/moretypes.js
@@ -1032,6 +1032,23 @@ onEvent("loaded", e => {
 				})
 			}
 		},
+		
+		psi: {
+			trick_crafting: (event, input, output, cad, trick, dimension) => {
+				let recipe = {
+					type: typeof dimension=="string" && dimension!=="" ? "psi:dimension_trick_crafting" : "psi:trick_crafting",
+					
+					input: Ingredient.of(input),
+					output: Ingredient.of(output),
+					cad: Ingredient.of(cad)
+				}
+				
+				if (typeof trick=="string" && trick!=="") recipe["trick"] = trick
+				if (recipe["type"]==="psi:dimension_trick_crafting") recipe["dimension"] = dimension
+				
+				event.custom(recipe)
+			}
+		},
 
 		silents_mechanisms: {
 			alloy_smelting: (event, input, output, time) => {


### PR DESCRIPTION
This Script adds a lot of new recipe types and also adds the ability to manually overwrite the id.
All Recipe Types have beenn tested and work. Support for new mods may also be added in the future.  
Wanted to add Support for Eidolon aswell, but it doesn't use JSON recipes, which then makes it impossible.
I also want to ask you if you would find it better if input and outputs are switched, cause most recipe types already added by kubejs and addons do it this way.
Also you may remove 1.18 as supported version, cause possibbly mods do this different in thos versions

PS.: I have another question though: what License would you recommend for KubeJS Ore Unification Scripts? Cause i'm not really sure what to use. And no i'm absolutly not asking cause i'm working on a Unification for Minecraft 1.16. Noo.